### PR TITLE
pmLock option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ See the available options in the table below.
 | hintlineStyle         | `{ color: 'red', dashArray: [5, 5] }` | [leaflet path options](https://leafletjs.com/reference-1.4.0.html#path) for the helper line between last drawn vertex and the cursor.                 |
 | cursorMarker          | `true`                                | show a marker at the cursor                                                                                                                           |
 | finishOn              | `null`                                | leaflet layer event to finish the drawn shape, like `'dblclick'`. [Here's a list](http://leafletjs.com/reference-1.2.0.html#interactive-layer-click). |
-| markerStyle           | `{ draggable: true }`                 | [leaflet marker options](https://leafletjs.com/reference-1.4.0.html#marker-icon) (only for drawing markers).                                          |
+| pathOptions           | `pmLock: false`                       | [leaflet path options](https://leafletjs.com/reference-1.4.0.html#path) (only for drawing path layers). `pmLock:true` lock the layer.                |
+| markerStyle           | `{ draggable: true, pmLock: false}`   | [leaflet marker options](https://leafletjs.com/reference-1.4.0.html#marker-icon) (only for drawing markers). `pmLock:true` lock the marker.          |
 
 You can listen to map events to hook into the drawing procedure like this:
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -338,8 +338,14 @@ map2.pm.disableDraw('Polygon');
 map2.pm.enableDraw('Line', { allowSelfIntersection: false });
 map2.pm.disableDraw('Line');
 
+//Lock the Layer
+map2.pm.enableDraw('Rectangle', { pathOptions:{ pmLock: true }});
+map2.pm.disableDraw('Rectangle');
+map2.pm.enableDraw('Marker', { markerStyle: { pmLock: true }});
+map2.pm.disableDraw('Marker');
+
 map2.on('pm:create', function(e) {
-  e.layer.pm.enable({ allowSelfIntersection: false });
+  //e.layer.pm.enable({ allowSelfIntersection: false });
   // e.layer.pm.disable();
   // console.log(e.layer.pm.hasSelfIntersection());
 

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -21,6 +21,8 @@ Draw.Cut = Draw.Polygon.extend({
       .filter(l => l instanceof L.Polygon)
       // exclude the drawn one
       .filter(l => l !== layer)
+      // exclude pmIgnore
+      .filter(l => l.options.pmLock !== true)
       // only layers with intersections
       .filter(l => {
         try {

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -84,7 +84,7 @@ const Map = L.Class.extend({
     return !!this._globalDragMode;
   },
   enableGlobalDragMode() {
-    const layers = this.findLayers();
+    const layers = this.findLayers().filter(l => l.options.pmLock !== true);
 
     this._globalDragMode = true;
 
@@ -163,7 +163,8 @@ const Map = L.Class.extend({
     const isRelevant = layer =>
       layer.pm &&
       !(layer.pm.options && layer.pm.options.preventMarkerRemoval) &&
-      !(layer instanceof L.LayerGroup);
+      !(layer instanceof L.LayerGroup) &&
+        !layer.options.pmLock;
 
     this._globalRemovalMode = true;
     // handle existing layers
@@ -195,7 +196,7 @@ const Map = L.Class.extend({
   },
   enableGlobalEditMode(options) {
     // find all layers handled by leaflet.pm
-    const layers = this.findLayers();
+    const layers = this.findLayers().filter(l => l.options.pmLock !== true);
 
     this._globalEditMode = true;
 


### PR DESCRIPTION
With pmLock layers can be locked and unlocked for editing.

Simply change the layer options to lock the layer: 
`layer.options.pmLock = true;` 
and unlock:
`layer.options.pmLock = false;` 

or: 
`map.pm.enableDraw('Rectangle', { pathOptions:{ pmLock: true }});`
`map.pm.enableDraw('Marker', { markerStyle:{ pmLock: true }});`