### PR TITLE
Drag Layergroup

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,30 +1,18 @@
 /* eslint-disable */
 // Provide your access token
-const accessToken =
-  'pk.eyJ1IjoibWFwc29mc3VtaXQiLCJhIjoiY2l1ZDF3dHE5MDAxZDMwbjA0cTR3dG50eSJ9.63Xci-GKFikhAobboF0DVQ';
+
+//Old MapTiles not working
 
 // set mapbox tile layer
-const mapboxTiles1 = L.tileLayer(
-  `https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=${accessToken}`,
-  {
-    attribution:
-      '&copy; <a href="https://www.mapbox.com/feedback/">Mapbox</a> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-  }
-);
-const mapboxTiles2 = L.tileLayer(
-  `https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=${accessToken}`,
-  {
-    attribution:
-      '&copy; <a href="https://www.mapbox.com/feedback/">Mapbox</a> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-  }
-);
-const mapboxTiles3 = L.tileLayer(
-  `https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=${accessToken}`,
-  {
-    attribution:
-      '&copy; <a href="https://www.mapbox.com/feedback/">Mapbox</a> &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-  }
-);
+const mapboxTiles1 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'});
+
+const mapboxTiles2 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'});
+
+const mapboxTiles3 = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'});
+
 
 const map2 = L.map('example2')
   .setView([51.505, -0.09], 13)
@@ -206,6 +194,7 @@ const theCollection = L.geoJson(geoJsonData, {
       return new L.Marker(latlng);
     }
   },
+  pmDrag: true
   // onEachFeature: (feature, layer) => {
   //     layer.addTo(map2);
   // },

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -12,7 +12,9 @@
   "actions": {
     "finish": "Finish",
     "cancel": "Cancel",
-    "removeLastVertex": "Remove Last Vertex"
+    "removeLastVertex": "Remove Last Vertex",
+    "layer": "Layer",
+    "layergroup": "Layergroup"
   },
   "buttonTitles": {
     "drawMarkerButton": "Draw Marker",

--- a/src/js/Edit/L.PM.Edit.LayerGroup.js
+++ b/src/js/Edit/L.PM.Edit.LayerGroup.js
@@ -1,9 +1,11 @@
 import Edit from './L.PM.Edit';
+import DragMixin from "../Mixins/Drag";
 
 // LayerGroup doesn't inherit from L.PM.Edit because it's just calling L.PM.Edit.Polygon
 // (which inherits from L.PM.Edit) for each layer,
 // so it's not really a parent class
 Edit.LayerGroup = L.Class.extend({
+  includes: [DragMixin],
   initialize(layerGroup) {
     this._layerGroup = layerGroup;
     this._layers = this.findLayers();

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -7,6 +7,8 @@ const Map = L.Class.extend({
     this.Draw = new L.PM.Draw(map);
     this.Toolbar = new L.PM.Toolbar(map);
 
+    this._dragMode = 1; //0 Layer, 1 Layergroup
+    this._layerGroupDragMenu = true;
     this._globalRemovalMode = false;
   },
   setLang(lang = 'en', t, fallback = 'en') {
@@ -54,7 +56,9 @@ const Map = L.Class.extend({
       if (
         layer instanceof L.Polyline ||
         layer instanceof L.Marker ||
-        layer instanceof L.Circle
+        layer instanceof L.Circle ||
+        layer instanceof L.LayerGroup && layer.options && layer.options.pmDrag
+
       ) {
         layers.push(layer);
       }
@@ -83,10 +87,23 @@ const Map = L.Class.extend({
   globalDragModeEnabled() {
     return !!this._globalDragMode;
   },
+  toggleLayerGroupDragMenu(){
+    this._layerGroupDragMenu = !this._layerGroupDragMenu;
+    this.Toolbar.reinit();
+  },
+  changeDragMode(mode){
+    this._dragMode = mode;
+    this.disableGlobalDragMode();
+    this.enableGlobalDragMode();
+  },
   enableGlobalDragMode() {
-    const layers = this.findLayers();
+    var layers = this.findLayers();
 
     this._globalDragMode = true;
+
+    if(this._dragMode === 0){
+      layers = layers.filter(l => !(l instanceof L.LayerGroup));
+    }
 
     layers.forEach(layer => {
       layer.pm.enableLayerDrag();

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -21,6 +21,14 @@ const PMButton = L.Control.extend({
     return this._container;
   },
   onRemove() {
+    //Disable all modes, else Toolbar Button need dbl click
+    this._map.pm.disableGlobalDragMode();
+    this._map.pm.disableGlobalEditMode();
+    this._map.pm.disableGlobalRemovalMode();
+    this._map.pm.Draw.Cut.disable();
+
+    this.toggle(false); //Disable button container
+
     this.buttonsDomNode.remove();
 
     return this._container;
@@ -99,9 +107,27 @@ const PMButton = L.Control.extend({
           this._map.pm.Draw[button.jsClass]._finishShape(e);
         },
       },
+      layer: {
+        text: getTranslation('actions.layer'),
+        onClick(e) {
+          this._map.pm.changeDragMode(0);
+        },
+      },
+      layergroup: {
+        text: getTranslation('actions.layergroup'),
+        onClick(e) {
+          this._map.pm.changeDragMode(1);
+        },
+      },
     };
 
     activeActions.forEach(name => {
+
+      if(!this._map.pm._layerGroupDragMenu && (name === 'layer' || name === 'layergroup')){
+        this._map.pm._dragMode = 0;
+        return;
+      }
+
       const action = actions[name];
       const actionNode = L.DomUtil.create(
         'a',

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -263,7 +263,7 @@ const Toolbar = L.Class.extend({
       disableOtherButtons: true,
       position: this.options.position,
       tool: 'edit',
-      actions: ['cancel'],
+      actions: ['layer','layergroup','cancel'],
     };
 
     const cutButton = {

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -10,7 +10,7 @@ export function getTranslation(path) {
   }
 
   let text = get(translations[lang], path);
-  if(text){ //Fallback to en
+  if(text){ //Fallback to english
     return text;
   }else{
     return get(translations['en'], path);

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -9,7 +9,12 @@ export function getTranslation(path) {
     lang = 'en';
   }
 
-  return get(translations[lang], path);
+  let text = get(translations[lang], path);
+  if(text){ //Fallback to en
+    return text;
+  }else{
+    return get(translations['en'], path);
+  }
 }
 
 export function isEmptyDeep(l) {


### PR DESCRIPTION
Add drag function for layergroups.
To drag a layergroup, it must have the option **pmDrag = true**.
But only L.FeatureGroup or L.GeoJSON are working, because of this: [https://github.com/Leaflet/Leaflet/issues/4861](https://github.com/Leaflet/Leaflet/issues/4861)

New map functions:
`toggleLayerGroupDragMenu(); //To change the menu items from drag (Layer,Layergroup,Cancle) || (Cancle)
changeDragMode(mode); //Change between dragging layers (0) or layergroups (1)`


Also added a fallback for not existing translations.

In L.Controls I change the onRemove function, because if it was called the buttons are vanished but the containers and modes are active / true.