### PR TITLE
Tiny PR: Use container class instead of button config to toggle control

### DIFF
--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -116,7 +116,7 @@ const PMButton = L.Control.extend({
     });
 
     if (button.toggleStatus) {
-      L.DomUtil.addClass(newButton, 'active');
+      L.DomUtil.addClass(buttonContainer, 'active');
     }
 
     const image = L.DomUtil.create('div', 'control-icon', newButton);


### PR DESCRIPTION
This seemed like a bug to me, as the toggling did not work on re-renders of my application.