### PR TITLE
Replace `optIn` with a `useType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@
 - [Customization](#customize)
 - [Need a feature?](#feature-request) | [Existing Feature Requests](https://github.com/geoman-io/leaflet-geoman/issues?q=is%3Aissue+is%3Aclosed+label%3A%22feature+request%22+sort%3Areactions-%2B1-desc)
 
-
 ### Installation
 
 #### Migrate from Leaflet.PM
@@ -51,6 +50,7 @@
 npm uninstall leaflet.pm
 npm i @geoman-io/leaflet-geoman-free
 ```
+
 That's it.
 
 #### Install via npm
@@ -93,8 +93,13 @@ import '@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css';
 
 #### Init leaflet-geoman
 
-Just include `leaflet-geoman.min.js` right after Leaflet. It initializes itself. If
-you want certain layers to be ignored by leaflet-geoman, pass `pmIgnore: true` to
+Just include `leaflet-geoman.min.js` right after Leaflet and initialize it with:
+
+```js
+L.PM.initialize();
+```
+
+If you want certain layers to be ignored by leaflet-geoman, pass `pmIgnore: true` to
 their options when creating them. Example:
 
 ```js
@@ -115,7 +120,6 @@ All layers will be ignored by leaflet-geoman, unless you specify `pmIgnore: fals
 L.marker([51.50915, -0.096112], { pmIgnore: false }).addTo(map);
 ```
 
-
 #### leaflet-geoman Toolbar
 
 <img align="left" height="200" src="https://file-ffrjxxowri.now.sh/" alt="leaflet-geoman Toolbar">
@@ -132,19 +136,19 @@ map.pm.addControls({
 
 See the available options in the table below.
 
-| Option        | Default     | Description                                                                                      |
-| :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
-| position      | `'topleft'` | toolbar position, possible values are `'topleft'`, `'topright'`, `'bottomleft'`, `'bottomright'` |
-| drawMarker    | `true`      | adds button to draw markers                                                                      |
-| drawCircleMarker    | `true`      | adds button to draw circle markers                                                                      |
-| drawPolyline  | `true`      | adds button to draw rectangle                                                                    |
-| drawRectangle | `true`      | adds button to draw rectangle                                                                    |
-| drawPolygon   | `true`      | adds button to draw polygon                                                                      |
-| drawCircle    | `true`      | adds button to draw circle                                                                       |
-| editMode      | `true`      | adds button to toggle edit mode for all layers                                                   |
-| dragMode      | `true`      | adds button to toggle drag mode for all layers                                                   |
-| cutPolygon    | `true`      | adds button to cut a hole in a polygon                                                           |
-| removalMode   | `true`      | adds a button to remove layers                                                                   |
+| Option           | Default     | Description                                                                                      |
+| :--------------- | :---------- | :----------------------------------------------------------------------------------------------- |
+| position         | `'topleft'` | toolbar position, possible values are `'topleft'`, `'topright'`, `'bottomleft'`, `'bottomright'` |
+| drawMarker       | `true`      | adds button to draw markers                                                                      |
+| drawCircleMarker | `true`      | adds button to draw circle markers                                                               |
+| drawPolyline     | `true`      | adds button to draw rectangle                                                                    |
+| drawRectangle    | `true`      | adds button to draw rectangle                                                                    |
+| drawPolygon      | `true`      | adds button to draw polygon                                                                      |
+| drawCircle       | `true`      | adds button to draw circle                                                                       |
+| editMode         | `true`      | adds button to toggle edit mode for all layers                                                   |
+| dragMode         | `true`      | adds button to toggle drag mode for all layers                                                   |
+| cutPolygon       | `true`      | adds button to cut a hole in a polygon                                                           |
+| removalMode      | `true`      | adds a button to remove layers                                                                   |
 
 If you are wondering how e.g. the `drawPolygon` button will enable drawing mode
 with specific options, here it is: Simply enable drawing mode programatically,
@@ -240,13 +244,13 @@ Here's a list of layer events you can listen to:
 | pm:centerplaced | `e`    | Called when the center of a circle is placed/moved.                                                                  |
 
 For making the snapping to other layers selective, you can add the "snapIgnore" option to your layers to disable the snapping to them during drawing.
+
 ```js
-L.geoJSON(data,{
-  snapIgnore : true
-})
+L.geoJSON(data, {
+  snapIgnore: true,
+});
 //This layer will be ignored by the snapping engine during drawing
 ```
-
 
 ### Edit Mode
 
@@ -324,6 +328,7 @@ map.on('pm:globaleditmodetoggled', e => {
   console.log(e);
 });
 ```
+
 The event has an object with an enabled boolean and a reference to the map.
 
 ### Drag Mode
@@ -355,6 +360,7 @@ map.on('pm:globaldrawmodetoggled', e => {
   console.log(e);
 });
 ```
+
 The event has an object with an enabled boolean and a reference to the map.
 
 ### Removal Mode
@@ -385,6 +391,7 @@ map.on('pm:globalremovalmodetoggled', e => {
   console.log(e);
 });
 ```
+
 The event has an object with an enabled boolean and a reference to the map.
 
 ### Cutting Mode

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -60,7 +60,12 @@ Draw.CircleMarker = Draw.Marker.extend({
     });
   },
   isRelevantMarker(layer) {
-    return layer instanceof L.CircleMarker && !(layer instanceof L.Circle) && layer.pm && !layer._pmTempLayer;
+    return (
+      layer instanceof L.CircleMarker &&
+      !(layer instanceof L.Circle) &&
+      layer.pm &&
+      !layer._pmTempLayer
+    );
   },
   _createMarker(e) {
     if (!e.latlng) {
@@ -83,6 +88,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     marker.addTo(this._map);
 
     // enable editing for the marker
+    marker.pm = marker.pm || new L.PM.Edit.CircleMarker(marker);
     marker.pm.enable();
 
     // fire the pm:create event and pass shape and marker

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -42,8 +42,15 @@ Draw.Cut = Draw.Polygon.extend({
       resultingLayer.addTo(this._map);
 
       // give the new layer the original options
-      resultingLayer.pm.enable(this.options);
-      resultingLayer.pm.disable();
+      // resultingLayer.pm =
+      //   resultingLayer.pm || new L.PM.Edit[this._shape](resultingLayer);
+      console.log('resulting layer');
+      console.log(resultingLayer);
+      if (resultingLayer.pm) {
+        console.log('resulting layer already has pm object');
+        resultingLayer.pm.enable(this.options);
+        resultingLayer.pm.disable();
+      }
 
       // fire pm:cut on the cutted layer
       l.fire('pm:cut', {

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -42,12 +42,7 @@ Draw.Cut = Draw.Polygon.extend({
       resultingLayer.addTo(this._map);
 
       // give the new layer the original options
-      // resultingLayer.pm =
-      //   resultingLayer.pm || new L.PM.Edit[this._shape](resultingLayer);
-      console.log('resulting layer');
-      console.log(resultingLayer);
       if (resultingLayer.pm) {
-        console.log('resulting layer already has pm object');
         resultingLayer.pm.enable(this.options);
         resultingLayer.pm.disable();
       }

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -129,6 +129,7 @@ Draw.Marker = Draw.extend({
     marker.addTo(this._map);
 
     // enable editing for the marker
+    marker.pm = marker.pm || new L.PM.Edit.Marker(marker);
     marker.pm.enable();
 
     // fire the pm:create event and pass shape and marker

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -70,7 +70,6 @@ const Map = L.Class.extend({
     return layers;
   },
   removeLayer(e) {
-
     const layer = e.target;
     // only remove layer, if it's handled by leaflet-geoman,
     // not a tempLayer and not currently being dragged
@@ -99,7 +98,7 @@ const Map = L.Class.extend({
 
     // toogle the button in the toolbar if this is called programatically
     this.Toolbar.toggleButton('dragMode', this._globalDragMode);
-    
+
     this._fireDragModeEvent(true);
   },
   disableGlobalDragMode() {
@@ -197,9 +196,9 @@ const Map = L.Class.extend({
   },
   _fireRemovalModeEvent(enabled) {
     this.map.fire('pm:globalremovalmodetoggled', {
-        enabled,
-        map: this.map,
-      });
+      enabled,
+      map: this.map,
+    });
   },
   toggleGlobalRemovalMode() {
     // toggle global edit mode

--- a/src/js/L.PM.js
+++ b/src/js/L.PM.js
@@ -32,6 +32,11 @@ import './Edit/L.PM.Edit.CircleMarker';
 import '../css/layers.css';
 import '../css/controls.css';
 
+const useTypes = {
+  ALL_LEAFLET_LAYERS: 'ALL_LEAFLET_LAYERS',
+  GEOMAN_LAYERS_ONLY: 'GEOMAN_LAYERS_ONLY',
+};
+
 L.PM = L.PM || {
   version,
   Map,
@@ -42,115 +47,51 @@ L.PM = L.PM || {
   initialize(options) {
     this.addInitHooks(options);
   },
-  addInitHooks(options = {}) {
+  addInitHooks(options) {
+    // eslint-disable-next-line func-names
+    L.Map.addInitHook(function() {
+      this.pm = new L.PM.Map(this);
+    });
 
-    function initMap() {
-      this.pm = undefined;
+    console.log(options);
 
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Map(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Map(this);
-      }
+    if (options.useType === useTypes.GEOMAN_LAYERS_ONLY) {
+      return;
     }
 
-    L.Map.addInitHook(initMap);
-
-    function initLayerGroup() {
-      // doesn't need pmIgnore condition as the init hook of the individual layers will check it
+    // eslint-disable-next-line func-names
+    L.LayerGroup.addInitHook(function() {
       this.pm = new L.PM.Edit.LayerGroup(this);
-    }
+    });
 
-    L.LayerGroup.addInitHook(initLayerGroup);
+    // eslint-disable-next-line func-names
+    L.Marker.addInitHook(function() {
+      this.pm = new L.PM.Edit.Marker(this);
+    });
 
-    function initMarker() {
-      this.pm = undefined;
+    // eslint-disable-next-line func-names
+    L.CircleMarker.addInitHook(function() {
+      this.pm = new L.PM.Edit.CircleMarker(this);
+    });
 
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.Marker(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.Marker(this);
-      }
-    }
+    // eslint-disable-next-line func-names
+    L.Polyline.addInitHook(function() {
+      this.pm = new L.PM.Edit.Line(this);
+    });
 
-    L.Marker.addInitHook(initMarker);
+    // eslint-disable-next-line func-names
+    L.Polygon.addInitHook(function() {
+      this.pm = new L.PM.Edit.Polygon(this);
+    });
 
-    function initCircleMarker() {
-      this.pm = undefined;
+    // eslint-disable-next-line func-names
+    L.Rectangle.addInitHook(function() {
+      this.pm = new L.PM.Edit.Rectangle(this);
+    });
 
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.CircleMarker(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.CircleMarker(this);
-      }
-    }
-    L.CircleMarker.addInitHook(initCircleMarker);
-
-
-    function initPolyline() {
-      this.pm = undefined;
-
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.Line(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.Line(this);
-      }
-    }
-
-    L.Polyline.addInitHook(initPolyline);
-
-    function initPolygon() {
-      this.pm = undefined;
-
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.Polygon(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.Polygon(this);
-      }
-
-    }
-
-    L.Polygon.addInitHook(initPolygon);
-
-    function initRectangle() {
-      this.pm = undefined;
-
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.Rectangle(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.Rectangle(this);
-      }
-    }
-
-    L.Rectangle.addInitHook(initRectangle);
-
-    function initCircle() {
-      this.pm = undefined;
-
-      if (options.optIn) {
-        if (this.options.pmIgnore === false) {
-          this.pm = new L.PM.Edit.Circle(this);
-        }
-      } else if (!this.options.pmIgnore) {
-        this.pm = new L.PM.Edit.Circle(this);
-      }
-    }
-
-    L.Circle.addInitHook(initCircle);
+    // eslint-disable-next-line func-names
+    L.Circle.addInitHook(function() {
+      this.pm = new L.PM.Edit.Circle(this);
+    });
   },
 };
-
-// initialize leaflet-geoman
-L.PM.initialize();

--- a/src/js/L.PM.js
+++ b/src/js/L.PM.js
@@ -53,8 +53,6 @@ L.PM = L.PM || {
       this.pm = new L.PM.Map(this);
     });
 
-    console.log(options);
-
     if (options.useType === useTypes.GEOMAN_LAYERS_ONLY) {
       return;
     }

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -221,7 +221,7 @@ const SnapMixin = {
         layers.push(layer);
 
         // this is for debugging
-        const debugLine = L.polyline([], { color: 'red', pmIgnore: true });
+        const debugLine = L.polyline([], { color: 'red' });
         debugLine._pmTempLayer = true;
         debugIndicatorLines.push(debugLine);
 


### PR DESCRIPTION
Hi @codeofsumit! 
In order to make your wonderful library work for me and to show our needs better I create this **Draft** PR. I started working on this, because my performance was significantly reduced. And I believe the root cause is the init hooks, that get added to every Leaflet layer. (I have a map with more than 10k Leaflet elements.)

As my changes change the mechanics of the library quite a bit, I want to include you as early as possible. And would love to hear if this makes sense to you and how we should work from here.

Short description of the changes. Before we had two attributes on different layers that were able to toggle the abilities of the library. That was `optIn` on a more global level and `pmIgnore` on a more local (layer) level. I found this concept hard to grasp and also as [commented on your initial PR](https://github.com/geoman-io/leaflet-geoman/pull/504#issuecomment-540600338)  #504 had some problems to make this work.
So to make the handling easier I introduced a `useType` which currently can have two values
* `ALL_LEAFLET_LAYERS` use geoman on all available Leaflet layers/objects 
* `GEOMAN_LAYERS_ONLY` use geoman only on layers drawn with geoman itself so only available to extended Leaflet classes

This obviously removes the possibility to enable geoman on a specific layer, as you could have done before. Adding this functionality could be done with another `useType` and handling it accordingly.

Another note: I haven't checked all use cases by far, and so it is very well possible that parts are not working as expected. I just want to get your thoughts first. Before investing more time.

Appreciate your time and looking for your feedback! 🎉 