### PR TITLE
Add edit option to keep snapped vertices together

### DIFF
--- a/cypress/integration/line.spec.js
+++ b/cypress/integration/line.spec.js
@@ -112,11 +112,11 @@ describe('Draw & Edit Line', () => {
 
     // draw a line
     cy.get(mapSelector)
-      .click(90, 250)
-      .click(100, 50)
-      .click(150, 50)
-      .click(150, 150)
-      .click(150, 150);
+      .click(390, 250)
+      .click(400, 50)
+      .click(450, 50)
+      .click(450, 150)
+      .click(450, 150);
 
     // button should be disabled after successful draw
     cy.toolbarButton('polyline')

--- a/cypress/integration/polygon.spec.js
+++ b/cypress/integration/polygon.spec.js
@@ -282,12 +282,12 @@ describe('Draw & Edit Poly', () => {
 
     // draw a polygon
     cy.get(mapSelector)
-      .click(90, 250)
-      .click(100, 50)
-      .click(150, 50)
-      .click(150, 150)
-      .click(200, 150)
-      .click(90, 250);
+      .click(390, 250)
+      .click(400, 50)
+      .click(450, 50)
+      .click(450, 150)
+      .click(500, 150)
+      .click(390, 250);
 
     // button should be disabled after successful draw
     cy.toolbarButton('polygon')

--- a/src/assets/translations/en.json
+++ b/src/assets/translations/en.json
@@ -13,7 +13,8 @@
   "actions": {
     "finish": "Finish",
     "cancel": "Cancel",
-    "removeLastVertex": "Remove Last Vertex"
+    "removeLastVertex": "Remove Last Vertex",
+    "keepVerticesSnapped": "Keep Snapped Vertices Together"
   },
   "buttonTitles": {
     "drawMarkerButton": "Draw Marker",

--- a/src/assets/translations/fr.json
+++ b/src/assets/translations/fr.json
@@ -12,7 +12,8 @@
   "actions": {
     "finish": "Terminer",
     "cancel": "Annuler",
-    "removeLastVertex": "Retirer le dernier sommet"
+    "removeLastVertex": "Retirer le dernier sommet",
+    "keepVerticesSnapped": "Garder les sommets rassemblés ensemble"
   },
   "buttonTitles": {
     "drawMarkerButton": "Placer des marqueurs",

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -104,6 +104,10 @@
   user-select: none;
 }
 
+.leaflet-pm-action-selected {
+  background-color: #2a2a2a ! important;
+}
+
 .button-container .leaflet-pm-actions-container .leaflet-pm-action:hover {
   cursor: pointer;
   background-color: #777;

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -8,6 +8,7 @@ const Map = L.Class.extend({
     this.Toolbar = new L.PM.Toolbar(map);
 
     this._globalRemovalMode = false;
+    this._globalEditKeepVerticesSnappedMode = false;
   },
   setLang(lang = 'en', t, fallback = 'en') {
     if (t) {
@@ -269,6 +270,13 @@ const Map = L.Class.extend({
       // enable
       this.enableGlobalEditMode(options);
     }
+  },
+  toggleGlobalEditKeepVerticesSnappedMode() {
+    this._globalEditKeepVerticesSnappedMode = !this._globalEditKeepVerticesSnappedMode;
+    return this._globalEditKeepVerticesSnappedMode;
+  },
+  globalEditKeepVerticesSnappedModeEnabled() {
+    return this._globalEditKeepVerticesSnappedMode;
   },
 });
 

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -99,6 +99,16 @@ const PMButton = L.Control.extend({
           this._map.pm.Draw[button.jsClass]._finishShape(e);
         },
       },
+      keepVerticesSnapped: {
+        text: getTranslation('actions.keepVerticesSnapped'),
+        onClick(e) {
+          if (this._map.pm.toggleGlobalEditKeepVerticesSnappedMode()) {
+            L.DomUtil.addClass(e.target, 'leaflet-pm-action-selected');
+          } else {
+            L.DomUtil.removeClass(e.target, 'leaflet-pm-action-selected');
+          }
+        },
+      },
     };
 
     activeActions.forEach(name => {

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -266,7 +266,7 @@ const Toolbar = L.Class.extend({
       disableOtherButtons: true,
       position: this.options.position,
       tool: 'edit',
-      actions: ['cancel'],
+      actions: ['keepVerticesSnapped', 'cancel'],
     };
 
     const dragButton = {


### PR DESCRIPTION
Following this [discussion](https://github.com/geoman-io/leaflet-geoman/issues/493) I have implemented an option for the edit tool to keep the snapped vertices together when dragging:

![geoman_pr2](https://user-images.githubusercontent.com/488992/73678929-6d823300-4687-11ea-9d70-f40fe00accb5.gif)

Note that this currently works for polygons and lines, but not for other shapes. I have also experimented with a mechanism allowing the "shared" middle markers to be moved together, but since it's more complex and has additional `turf` dependencies, I'm not including it in this PR.

If there's any interest in the feature I will add some related tests.