### PR TITLE
Swedish translations

### DIFF
--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -18,7 +18,7 @@
   "buttonTitles": {
     "drawMarkerButton": "Rita Markör",
     "drawPolyButton": "Rita Polygoner",
-    "drawLineButton": "Rita Polylinje",
+    "drawLineButton": "Rita Linje",
     "drawCircleButton": "Rita Cirkel",
     "drawRectButton": "Rita Rektangel",
     "editButton": "Redigera Lager",

--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -1,7 +1,7 @@
 {
   "tooltips": {
     "placeMarker": "Klicka för att placera punkt",
-    "firstVertex": "Klicka för att placera första vertex",
+    "firstVertex": "Klicka för att placera första hörnet",
     "continueLine": "Klicka för att fortsätta rita",
     "finishLine": "Klicka på en existerande punkt för att slutföra",
     "finishPoly": "Klicka på den första punkten för att slutföra",
@@ -13,14 +13,14 @@
   "actions": {
     "finish": "Slutför",
     "cancel": "Avbryt",
-    "removeLastVertex": "Ta bort sista vertex"
+    "removeLastVertex": "Ta bort sista hörnet"
   },
   "buttonTitles": {
     "drawMarkerButton": "Rita Punkt",
     "drawPolyButton": "Rita Polygoner",
-    "drawLineButton": "Rita Polyline",
+    "drawLineButton": "Rita Polylinje",
     "drawCircleButton": "Rita Cirkel",
-    "drawRectButton": "Rita Rectangle",
+    "drawRectButton": "Rita Rektangel",
     "editButton": "Redigera Lager",
     "dragButton": "Dra Lager",
     "cutButton": "Klipp i Lager",

--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -1,6 +1,6 @@
 {
   "tooltips": {
-    "placeMarker": "Klicka för att placera punkt",
+    "placeMarker": "Klicka för att placera markör",
     "firstVertex": "Klicka för att placera första hörnet",
     "continueLine": "Klicka för att fortsätta rita",
     "finishLine": "Klicka på en existerande punkt för att slutföra",
@@ -16,7 +16,7 @@
     "removeLastVertex": "Ta bort sista hörnet"
   },
   "buttonTitles": {
-    "drawMarkerButton": "Rita Punkt",
+    "drawMarkerButton": "Rita Markör",
     "drawPolyButton": "Rita Polygoner",
     "drawLineButton": "Rita Polylinje",
     "drawCircleButton": "Rita Cirkel",

--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -8,7 +8,7 @@
     "finishRect": "Klicka för att slutföra",
     "startCircle": "Klicka för att placera cirkelns centrum",
     "finishCircle": "Klicka för att slutföra cirkeln",
-    "placeCircleMarker": "Klicka för att placera cirkelmakör"
+    "placeCircleMarker": "Klicka för att placera cirkelmarkör"
   },
   "actions": {
     "finish": "Slutför",
@@ -17,14 +17,14 @@
   },
   "buttonTitles": {
     "drawMarkerButton": "Rita Punkt",
-    "drawPolyButton": "Rita Rolygoner",
+    "drawPolyButton": "Rita Polygoner",
     "drawLineButton": "Rita Polyline",
-    "drawCircleButton": "Rta Cirkel",
+    "drawCircleButton": "Rita Cirkel",
     "drawRectButton": "Rita Rectangle",
     "editButton": "Redigera Lager",
     "dragButton": "Dra Lager",
     "cutButton": "Klipp i Lager",
     "deleteButton": "Ta bort Lager",
-    "drawCircleMarkerButton": "Rita Cirkelmakör"
+    "drawCircleMarkerButton": "Rita Cirkelmarkör"
   }
 }


### PR DESCRIPTION
There were some misspellings and remaining english words.
Also I have translated "marker" with "markör" instead of "punkt" (similar to the already existing translation of "circle marker" ==> "cirkelmarkör").
However, I can mention that it was intentional to leave the word "punkt" in the following translation:
"finishLine": "Klicka på en existerande punkt för att slutföra",
because I think that it is more appropriate to use the word "punkt" (point) in that sentence.
I am a native swedish speaker, so I can not say the following for sure regarding the english but IMHO I believe that the current english translation should use "point" instead of "marker" here:
"finishLine": "Click any existing marker to finish",
i.e. instead should be:
"finishLine": "Click any existing point to finish",
I think it is normal semantic that a line has many points while a "marker" rather represents some more specific point i.e. not all points in a line should be thought of as markers. IMHO.