### PR TITLE
Bugfix Marker drag snapping

### DIFF
--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -4,6 +4,11 @@ const DragMixin = {
     this.disable();
 
     if (this._layer instanceof L.Marker) {
+      if(this.options.snappable) {
+        this._initSnappableMarkers();
+      }else{
+        this._disableSnapping();
+      }
       this._layer.dragging.enable();
       return;
     }


### PR DESCRIPTION
Bug: If drag mode is enabled bevor edit mode was enabled, marker is not snapping to layers.

1. enable drag mode
2. drag marker along layer => not snapping
3. enable edit mode
4. enable drag mode
2. drag marker along layer => snapping

[jsfiddle](https://jsfiddle.net/falkedesign/2jv64bh9/)