### PR TITLE
Toolbar customization - Draw Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,18 +580,20 @@ map.pm.addControls({
      editControls: false,
      optionsControls: true,
      customControls: true,
+     oneBlock: false
  })
 ```
 
 To display the Toolbar as one block you can pass in to the `addControls(options)` function `oneBlock: true`. 
 
-If you want to change the order in a section you can use `map.pm.Toolbar.changeControlOrder(['Circle','Rectangle','Removal','Edit'])`.
-You can pass all shape names and `Edit`, `Drag`, `Removal`, `Cut`.
+If you want to change the order in a section you can use `map.pm.Toolbar.changeControlOrder(['Circle','Rectangle','Removal','Edit'])` to sort from Top to Bottom.
+You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut`.
 
 With `map.pm.Toolbar.getControlOrder()` you get the current order of the controls.
 
 **New Control**
-With `map.pm.Toolbar.createCustomButton(options)` you can create a new control.
+
+With `map.pm.Toolbar.createCustomControl(options)` you can create a new control.
 
 | Option        | Default     | Description                                                                                      |
 | :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
@@ -605,6 +607,7 @@ With `map.pm.Toolbar.createCustomButton(options)` you can create a new control.
 | toggle        | true        | Control can be toggled |
 
 **Actions**
+
 You can use the default actions: `cancel`, `removeLastVertex`, `finish`, `finishMode` (Only for modes `Edit`, `Drag`, `Removal`).
 
 Or you can create actions:
@@ -613,17 +616,37 @@ Or you can create actions:
 var actions = ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
 ```
 
+The following methods are available on `map.pm.Toolbar`:
+
+| Method                         | Returns   | Description                                                                                                   |
+| :----------------------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
+| createCustomControl(`options`) | -         | To add a custom Control to the Toolbar.                                                                       |
+| changeControlOrder(`shapes`)   | -         | Change the order of the controls in the Toolbar. You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut` |
+| getControlOrder()              | `Array`   | Get the current order of the controls.                                                                        |
+
+
 **New Draw Instance**
+
 If you want to add more Draw controls you have to create a new Instance `map.pm.Draw.createNewDrawInstance(name,jsClass)`.
 It's important that you use the same name for the new Instance and the custom control:
 ```javascript
 var poly = map.pm.Draw.createNewDrawInstance("Polygon2","Polygon");
 poly.setPathOptions({color :'red'});
+map.pm.enableDraw("Polygon2");
+
+// You can add also the new Instance to the Toolbar
 var afterClick = () => {
     poly.toggle();
 };
-map.pm.Toolbar.createCustomButton({name: "Polygon2", afterClick: afterClick})
+map.pm.Toolbar.createCustomControl({name: "Polygon2", afterClick: afterClick})
 ```
+
+
+The following methods are available on `map.pm.Draw`:
+
+| Method                                  | Returns   | Description                              |
+| :-------------------------------------- | :-------- | :--------------------------------------- |
+| createNewDrawInstance(`name`,`jsClass`) | -         | Creates a new Draw Instance.             |
 
 
 ### Feature Request

--- a/README.md
+++ b/README.md
@@ -569,6 +569,16 @@ map.pm.setPathOptions({
 });
 ```
 
+You can ignore shapes when you add an array with the shape names:
+```javascript
+map.pm.setPathOptions({
+  color: 'orange',
+  fillColor: 'green',
+  fillOpacity: 0.4,
+}, ["Circle","Rectangle"]);
+```
+
+
 ##### Customize Controls
 
 There are 4 control sections / containers. `draw`, `edit`, `options`⭐, `custom`

--- a/README.md
+++ b/README.md
@@ -598,19 +598,19 @@ With `map.pm.Toolbar.createCustomControl(options)` you can create a new control.
 | Option        | Default     | Description                                                                                      |
 | :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
 | name          | Required    | Name of the control |
-| tool          | ''          | Section / container of the control. `` ==  `draw`, `edit`, `options`⭐, `custom` |
+| tool          | ''          | Section / container of the control. ` ` == `draw`, `edit`, `options`⭐, `custom` |
 | title         | ''          | Text showing when you hover the control |
 | className     | ''          | CSS class with the Icon |
 | onClick       | -           | Function fired when clicking the control |
 | afterClick    | -           | Function fired after clicking the control |
-| actions       | []          | Action that appears as tooltip. Look under [actions](#actions) for more information |
+| actions       | [ ]          | Action that appears as tooltip. Look under [actions](#actions) for more information |
 | toggle        | true        | Control can be toggled |
 
 **Actions**
 
 You can use the default actions: `cancel`, `removeLastVertex`, `finish`, `finishMode` (Only for modes `Edit`, `Drag`, `Removal`).
 
-Or you can create actions:
+Or you can create own actions:
 
 ```javascript
 var actions = ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]

--- a/README.md
+++ b/README.md
@@ -569,6 +569,63 @@ map.pm.setPathOptions({
 });
 ```
 
+##### Customize Controls
+
+There are 4 control sections / containers. `draw`, `edit`, `options`⭐, `custom`
+
+You can disable / enable each section with:
+```
+map.pm.addControls({
+     drawControls: true,
+     editControls: false,
+     optionsControls: true,
+     customControls: true,
+ })
+```
+
+To display the Toolbar as one block you can pass in to the `addControls(options)` function `oneBlock: true`. 
+
+If you want to change the order in a section you can use `map.pm.Toolbar.changeControlOrder(['Circle','Rectangle','Removal','Edit'])`.
+You can pass all shape names and `Edit`, `Drag`, `Removal`, `Cut`.
+
+With `map.pm.Toolbar.getControlOrder()` you get the current order of the controls.
+
+**New Control**
+With `map.pm.Toolbar.createCustomButton(options)` you can create a new control.
+
+| Option        | Default     | Description                                                                                      |
+| :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
+| name          | Required    | Name of the control |
+| tool          | ''          | Section / container of the control. `` ==  `draw`, `edit`, `options`⭐, `custom` |
+| title         | ''          | Text showing when you hover the control |
+| className     | ''          | CSS class with the Icon |
+| onClick       | -           | Function fired when clicking the control |
+| afterClick    | -           | Function fired after clicking the control |
+| actions       | []          | Action that appears as tooltip. Look under [actions](#actions) for more information |
+| toggle        | true        | Control can be toggled |
+
+**Actions**
+You can use the default actions: `cancel`, `removeLastVertex`, `finish`, `finishMode` (Only for modes `Edit`, `Drag`, `Removal`).
+
+Or you can create actions:
+
+```javascript
+var actions = ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
+```
+
+**New Draw Instance**
+If you want to add more Draw controls you have to create a new Instance `map.pm.Draw.createNewDrawInstance(name,jsClass)`.
+It's important that you use the same name for the new Instance and the custom control:
+```javascript
+var poly = map.pm.Draw.createNewDrawInstance("Polygon2","Polygon");
+poly.setPathOptions({color :'red'});
+var afterClick = () => {
+    poly.toggle();
+};
+map.pm.Toolbar.createCustomButton({name: "Polygon2", afterClick: afterClick})
+```
+
+
 ### Feature Request
 
 I'm adopting the Issue Management of lodash which means, feature requests get the "Feature Request" Label and then get closed.

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ In order to change the style of the lines during draw, pass these options to the
 
 ```js
 // optional options for line style during draw. These are the defaults
-var options = {
+const options = {
   // the lines between coordinates/markers
   templineStyle: {
     color: 'red',
@@ -597,7 +597,7 @@ pass the options to `enableDraw`:
 
 ```js
 // optional options for line style during draw. These are the defaults
-var options = {
+const options = {
   templineStyle: {},
   hintlineStyle: {},
   pathOptions: {
@@ -621,13 +621,17 @@ map.pm.setPathOptions({
 });
 ```
 
-You can ignore shapes when you add an array with the shape names:
+You can ignore shapes when you add an array with the shape names to the second object with `ignoreShapes`:
 ```javascript
 map.pm.setPathOptions({
-  color: 'orange',
-  fillColor: 'green',
-  fillOpacity: 0.4,
-}, ["Circle","Rectangle"]);
+      color: 'orange',
+      fillColor: 'green',
+      fillOpacity: 0.4,
+    },
+    {
+      ignoreShapes: ["Circle", "Rectangle"]
+    }
+);
 ```
 
 
@@ -648,8 +652,7 @@ map.pm.addControls({
 
 To display the Toolbar as one block you can pass in to the `addControls(options)` function `oneBlock: true`. 
 
-If you want to change the order in a section you can use `map.pm.Toolbar.changeControlOrder(['Circle','Rectangle','Removal','Edit'])` to sort from Top to Bottom.
-You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut`.
+If you want to change the order in a section you can use `map.pm.Toolbar.changeControlOrder(['drawCircle','drawRectangle','removalMode','editMode'])` to sort from Top to Bottom.
 
 With `map.pm.Toolbar.getControlOrder()` you get the current order of the controls.
 
@@ -660,13 +663,22 @@ With `map.pm.Toolbar.createCustomControl(options)` you can create a new control.
 | Option        | Default     | Description                                                                                      |
 | :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
 | name          | Required    | Name of the control |
-| tool          | ''          | Section / container of the control. ` ` == `draw`, `edit`, `options`⭐, `custom` |
+| block         | ''          | Section / container of the control. ` ` == `draw`, `edit`, `options`⭐, `custom` |
 | title         | ''          | Text showing when you hover the control |
 | className     | ''          | CSS class with the Icon |
 | onClick       | -           | Function fired when clicking the control |
 | afterClick    | -           | Function fired after clicking the control |
 | actions       | [ ]          | Action that appears as tooltip. Look under [actions](#actions) for more information |
 | toggle        | true        | Control can be toggled |
+
+**Copy of Control**
+
+You can copy an available control and add new options to it with `copyDrawControl(instance,options)`:
+
+```javascript
+map.pm.Toolbar.copyDrawControl("Rectangle", {name:"RectangleCopy",block: "custom",title: "Display text on hover button",actions: actions});
+```
+
 
 **Actions**
 
@@ -675,41 +687,23 @@ You can use the default actions: `cancel`, `removeLastVertex`, `finish`, `finish
 Or you can create own actions:
 
 ```javascript
-var actions = ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
+const actions = ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
+```
+
+You can change actions of existing buttons with `changeActionsOfControl(name, actions)`:
+```javascript
+map.pm.Toolbar.changeActionsOfControl('Rectangle',["cancel"])
 ```
 
 The following methods are available on `map.pm.Toolbar`:
 
-| Method                         | Returns   | Description                                                                                                   |
-| :----------------------------- | :-------- | :------------------------------------------------------------------------------------------------------------ |
-| createCustomControl(`options`) | -         | To add a custom Control to the Toolbar.                                                                       |
-| changeControlOrder(`shapes`)   | -         | Change the order of the controls in the Toolbar. You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut` |
-| getControlOrder()              | `Array`   | Get the current order of the controls.                                                                        |
-
-
-**New Draw Instance**
-
-If you want to add more Draw controls you have to create a new Instance `map.pm.Draw.createNewDrawInstance(name,jsClass)`.
-It's important that you use the same name for the new Instance and the custom control:
-```javascript
-var poly = map.pm.Draw.createNewDrawInstance("Polygon2","Polygon");
-poly.setPathOptions({color :'red'});
-map.pm.enableDraw("Polygon2");
-
-// You can add also the new Instance to the Toolbar
-var afterClick = () => {
-    poly.toggle();
-};
-map.pm.Toolbar.createCustomControl({name: "Polygon2", afterClick: afterClick})
-```
-
-
-The following methods are available on `map.pm.Draw`:
-
-| Method                                  | Returns   | Description                              |
-| :-------------------------------------- | :-------- | :--------------------------------------- |
-| createNewDrawInstance(`name`,`jsClass`) | -         | Creates a new Draw Instance.             |
-
+| Method                                      | Returns   | Description                                                                                                   |
+| :------------------------------------------ | :-------- | :------------------------------------------------------------------------------------------------------------ |
+| createCustomControl(`options`)              | -         | To add a custom Control to the Toolbar.                                                                       |
+| copyDrawControl(`instance`,`options`)       | `Object`  | Creates a copy of a draw Control. Returns the `drawInstance` and the `control`.                               |
+| changeActionsOfControl(`name`,`actions`)    | -         | Change the actions of an existing button.                                                                     |
+| changeControlOrder(`shapes`)                | -         | Change the order of the controls in the Toolbar. You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut` |
+| getControlOrder()                           | `Array`   | Get the current order of the controls.                                                                        |
 
 ### Feature Request
 

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -6,7 +6,7 @@ describe('Testing the Toolbar', () => {
       .parent('.leaflet-top.leaflet-left')
       .should('exist');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.addControls({
         position: 'topright',
       });
@@ -24,7 +24,7 @@ describe('Testing the Toolbar', () => {
 
     cy.get('.button-container.active .action-cancel').click();
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.addControls({
         position: 'bottomright',
       });
@@ -34,7 +34,7 @@ describe('Testing the Toolbar', () => {
       .parent('.leaflet-bottom.leaflet-right')
       .should('exist');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.addControls({
         position: 'bottomleft',
       });
@@ -44,7 +44,7 @@ describe('Testing the Toolbar', () => {
       .parent('.leaflet-bottom.leaflet-left')
       .should('exist');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.addControls({
         position: 'topleft',
       });
@@ -95,7 +95,7 @@ describe('Testing the Toolbar', () => {
   });
 
   it('Reacts to programmatic state change', () => {
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.enableGlobalEditMode();
     });
 
@@ -103,7 +103,7 @@ describe('Testing the Toolbar', () => {
       .closest('.button-container')
       .should('have.class', 'active');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.toggleGlobalRemovalMode();
     });
 
@@ -114,7 +114,7 @@ describe('Testing the Toolbar', () => {
       .closest('.button-container')
       .should('have.class', 'active');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.toggleGlobalRemovalMode();
       map.pm.toggleGlobalRemovalMode();
       map.pm.toggleGlobalRemovalMode();
@@ -124,7 +124,7 @@ describe('Testing the Toolbar', () => {
       .closest('.button-container')
       .should('have.not.class', 'active');
 
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.toggleGlobalEditMode();
       map.pm.toggleGlobalRemovalMode();
 
@@ -147,7 +147,7 @@ describe('Testing the Toolbar', () => {
   });
 
   it('Has Working translation for circle marker toolbar button', () => {
-    cy.window().then(({ map }) => {
+    cy.window().then(({map}) => {
       map.pm.setLang('es');
     });
 
@@ -186,5 +186,132 @@ describe('Testing the Toolbar', () => {
     cy.get('.button-container.active .action-finishMode').click();
 
     cy.hasVertexMarkers(0);
+  });
+
+
+  it('Custom Controls - new button', () => {
+    cy.get('.leaflet-pm-toolbar')
+      .parent('.leaflet-top.leaflet-left')
+      .should('exist');
+
+
+    cy.window().then(({map, L}) => {
+      let testresult = "";
+
+      // Click button -> toggle disabled
+      map.pm.Toolbar.createCustomControl({
+        name: "clickButton",
+        tool: "custom",
+        className: "leaflet-pm-icon-marker",
+        title: "Count layers",
+        onClick: () => {
+          testresult = "clickButton clicked";
+        },
+        toggle: false
+      });
+      cy.toolbarButtonContainer('clickButton', map).then((container) => {
+        cy.get(container[0].children[0].children[0]).should('have.attr', 'title').and('include', 'Count layers');
+        container[0].children[0].click(); // button
+        expect(testresult).to.equal("clickButton clicked");
+        cy.get(container).should('not.have.class', 'active');
+      });
+    });
+  });
+
+
+  it('Custom Controls - new draw instance', () => {
+    cy.get('.leaflet-pm-toolbar')
+      .parent('.leaflet-top.leaflet-left')
+      .should('exist');
+
+
+    cy.window().then(({map}) => {
+      let testresult = "";
+      let testlayer;
+
+      // New Instance of Polygon Button
+      // It's very important that the name of the instance createNewDrawInstance(name, ...) is the same in createCustomControl(name, ...)
+      const poly = map.pm.Draw.createNewDrawInstance("Polygon2", "Polygon");
+      poly.setPathOptions({color: 'red'});
+      const afterClick = () => {
+        poly.toggle();
+      };
+      const actions = ['cancel', {text: 'Custom text, no click'}, {
+        text: 'Click event', onClick: () => {
+          testresult = 'click';
+        }
+      }];
+      map.pm.Toolbar.createCustomControl({
+        name: "Polygon2",
+        tool: "custom",
+        className: "leaflet-pm-icon-polygon",
+        title: "Display text on hover button",
+        afterClick,
+        actions
+      });
+
+      cy.toolbarButtonContainer('Polygon2', map).then((container) => {
+        cy.get(container[0].children[0].children[0]).should('have.attr', 'title').and('include', 'Display text on hover button');
+        cy.get(container[0].children[0]).click(); // button
+        cy.get(container).should('have.class', 'active');
+        const actions = container[0].children[1].children;
+        const actioncount = actions.length;
+        expect(actioncount).to.equal(3);
+
+        cy.get(actions[2]).click().then(() => {
+          expect(testresult).to.equal("click");
+          expect(actions[1].innerHTML).to.equal("Custom text, no click");
+        });
+
+        cy.get(actions[0]).click();
+        cy.get(container).should('not.have.class', 'active');
+        cy.window().then(({map, L}) => {
+          map.pm.enableDraw('Polygon2');
+          map.on('pm:create', (e) => {
+            e.layer.on('click', (l) => testlayer = l.target)
+          })
+        });
+        cy.get(container).should('have.class', 'active');
+        // draw a polygon
+        cy.get(mapSelector)
+          .click(450, 100)
+          .click(450, 150)
+          .click(400, 150)
+          .click(390, 140)
+          .click(390, 100)
+          .click(450, 100);
+
+
+        cy.get(mapSelector).click(390, 140).then(() => {
+          console.log(testlayer);
+          expect(testlayer.options.color).to.equal("red");
+        })
+      })
+    });
+  });
+
+
+  it('Custom Controls - Custom order', () => {
+    cy.window().then(({map}) => {
+      map.pm.Toolbar.changeControlOrder(["Rectangle"]);
+      cy.get('.leaflet-pm-toolbar.leaflet-pm-draw').then((container) => {
+        cy.get(container[0].children[0]).then((e) => {
+          cy.get(e[0].children[0].children[0]).should('have.class', 'leaflet-pm-icon-rectangle');
+        })
+      })
+
+    });
+  });
+
+
+  it.only('Custom Controls - One Block', () => {
+    cy.window().then(({map}) => {
+      map.pm.addControls({
+        oneBlock: true
+      });
+      cy.get('.leaflet-pm-toolbar.leaflet-pm-draw').then((container) => {
+        expect(container[0].children.length).to.equal(10);
+      })
+    });
   });
 });

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -201,7 +201,7 @@ describe('Testing the Toolbar', () => {
       // Click button -> toggle disabled
       map.pm.Toolbar.createCustomControl({
         name: "clickButton",
-        tool: "custom",
+        block: "custom",
         className: "leaflet-pm-icon-marker",
         title: "Count layers",
         onClick: () => {
@@ -229,28 +229,22 @@ describe('Testing the Toolbar', () => {
       let testresult = "";
       let testlayer;
 
-      // New Instance of Polygon Button
-      // It's very important that the name of the instance createNewDrawInstance(name, ...) is the same in createCustomControl(name, ...)
-      const poly = map.pm.Draw.createNewDrawInstance("Polygon2", "Polygon");
-      poly.setPathOptions({color: 'red'});
-      const afterClick = () => {
-        poly.toggle();
-      };
+      // Copy of Polygon Button
       const actions = ['cancel', {text: 'Custom text, no click'}, {
         text: 'Click event', onClick: () => {
           testresult = 'click';
         }
       }];
-      map.pm.Toolbar.createCustomControl({
-        name: "Polygon2",
-        tool: "custom",
+      map.pm.Toolbar.copyDrawControl("Polygon", {
+        name: "PolygonCopy",
+        block: "custom",
         className: "leaflet-pm-icon-polygon",
         title: "Display text on hover button",
-        afterClick,
         actions
       });
+      map.pm.Draw.PolygonCopy.setPathOptions({color :'red'});
 
-      cy.toolbarButtonContainer('Polygon2', map).then((container) => {
+      cy.toolbarButtonContainer('PolygonCopy', map).then((container) => {
         cy.get(container[0].children[0].children[0]).should('have.attr', 'title').and('include', 'Display text on hover button');
         cy.get(container[0].children[0]).click(); // button
         cy.get(container).should('have.class', 'active');
@@ -266,7 +260,7 @@ describe('Testing the Toolbar', () => {
         cy.get(actions[0]).click();
         cy.get(container).should('not.have.class', 'active');
         cy.window().then(({map, L}) => {
-          map.pm.enableDraw('Polygon2');
+          map.pm.enableDraw('PolygonCopy');
           map.on('pm:create', (e) => {
             e.layer.on('click', (l) => testlayer = l.target)
           })
@@ -304,7 +298,7 @@ describe('Testing the Toolbar', () => {
   });
 
 
-  it.only('Custom Controls - One Block', () => {
+  it('Custom Controls - One Block', () => {
     cy.window().then(({map}) => {
       map.pm.addControls({
         oneBlock: true

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -105,6 +105,10 @@ Cypress.Commands.add('toolbarButton', name =>
   cy.get(`.leaflet-pm-icon-${name}`)
 );
 
+Cypress.Commands.add('toolbarButtonContainer', (name, map) => {
+  cy.get(map.pm.Toolbar.buttons[name]._container.children[0])
+});
+
 Cypress.Commands.add('drawShape', (shape, ignore) => {
   cy.window().then(({ map, L }) => {
     if (shape === 'PolygonPart1') {

--- a/demo/customcontrols.html
+++ b/demo/customcontrols.html
@@ -1,0 +1,35 @@
+<!DOCTYPE>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Leaflet Polygon Management Demo</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+    <link rel="stylesheet" href="../dist/leaflet-geoman.css">
+    <link rel="stylesheet" href="demo.css" />
+    <script src="https://unpkg.com/leaflet@latest/dist/leaflet.js"></script>
+
+    <!-- <script src="../../leaflet-measure-path/leaflet-measure-path.js"></script> -->
+    <!-- <script src="https://unpkg.com/leaflet.markercluster@1.0.0"></script> -->
+
+</head>
+
+<body>
+
+    <div class="wrapper">
+
+        <article>
+            <h1>Leaflet Geoman</h1>
+            <h3>An Open Source Leaflet Plugin for editing polygons, specifically made for Leaflet 1.0</h3>
+        </article>
+        <article>
+            <h2>Custom Controls in the Toolbar</h2>
+            <div class="map" id="example2"></div>
+
+        </article>
+    </div>
+    <script src="../dist/leaflet-geoman.min.js"></script>
+    <script src="customcontrols.js"></script>
+</body>
+
+</html>

--- a/demo/customcontrols.js
+++ b/demo/customcontrols.js
@@ -1,0 +1,77 @@
+var map = L.map('example2').setView([40.0269319,32.83604819], 13);
+
+L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw', {
+    maxZoom: 180,
+    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
+      '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+      'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+    id: 'mapbox.light'
+}).addTo(map);
+
+
+map.pm.addControls({
+    position: 'topleft',
+    drawControls: false,
+    editControls: true,
+    optionsControls: true,
+    customControls: true,
+    oneBlock: false
+});
+
+// Click button -> toggle disabled
+map.pm.Toolbar.createCustomControl({name:"alertBox",tool: "custom",className: "leaflet-pm-icon-marker",title: "Count layers",onClick: ()=>{alert("There are "+L.PM.Utils.findLayers(map).length+" layers on the map")},toggle: false});
+
+// New Instance of Polygon Button
+// It's very important that the name of the instance createNewDrawInstance(name, ...) is the same in createCustomControl(name, ...)
+var poly = map.pm.Draw.createNewDrawInstance("Polygon2","Polygon");
+poly.setPathOptions({color :'red'});
+var afterClick = () => {
+    poly.toggle();
+};
+var actions = ['finish', 'removeLastVertex', 'cancel']
+actions =  ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
+map.pm.Toolbar.createCustomControl({name:"Polygon2",tool: "custom",className:"leaflet-pm-icon-polygon",title: "Display text on hover button",afterClick: afterClick, actions: actions});
+
+//Custom action
+var circle = map.pm.Draw.createNewDrawInstance("Circle2","Circle");
+circle.setPathOptions({color :'green'});
+var afterClick = () => {
+    circle.toggle();
+};
+var act = {
+    text: 'Custom action',
+    onClick(e){
+        alert('click')
+    }
+};
+var actions2 = [act,'cancel'];
+map.pm.Toolbar.createCustomControl({name:"Circle2",tool: "custom",className:"leaflet-pm-icon-circle",title: "Display text on hover button",afterClick: afterClick,actions: actions2});
+
+
+//Add to edit container
+var rectangle = map.pm.Draw.createNewDrawInstance("Rectangle2","Rectangle");
+var afterClick = () => {
+    rectangle.toggle();
+};
+var container = "edit";
+var actions3 = ['cancel'];
+map.pm.Toolbar.createCustomControl({name:"Rectangle2",tool: container,className:"leaflet-pm-icon-rectangle",title: "Display text on hover button",afterClick: afterClick,actions: actions3});
+
+rectangle.setPathOptions({color :'orange'});
+
+//Show message
+var rectangle3 = map.pm.Draw.createNewDrawInstance("Rectangle3","Rectangle");
+var afterClick = () => {
+    rectangle3.toggle();
+};
+var actions4 = [{text: "Custom message, no click event"}];
+map.pm.Toolbar.createCustomControl({name:"Rectangle3",tool: "custom",className:"leaflet-pm-icon-rectangle",title: "Display text on hover button",afterClick: afterClick,actions: actions4});
+
+map.pm.Toolbar.changeControlOrder(["Rectangle3"])
+rectangle3.setPathOptions({color :'green'});
+
+
+
+
+
+

--- a/demo/customcontrols.js
+++ b/demo/customcontrols.js
@@ -19,59 +19,14 @@ map.pm.addControls({
 });
 
 // Click button -> toggle disabled
-map.pm.Toolbar.createCustomControl({name:"alertBox",tool: "custom",className: "leaflet-pm-icon-marker",title: "Count layers",onClick: ()=>{alert("There are "+L.PM.Utils.findLayers(map).length+" layers on the map")},toggle: false});
-
-// New Instance of Polygon Button
-// It's very important that the name of the instance createNewDrawInstance(name, ...) is the same in createCustomControl(name, ...)
-var poly = map.pm.Draw.createNewDrawInstance("Polygon2","Polygon");
-poly.setPathOptions({color :'red'});
-var afterClick = () => {
-    poly.toggle();
-};
-var actions = ['finish', 'removeLastVertex', 'cancel']
-actions =  ['cancel', {text: 'Custom text, no click'}, {text: 'Click event', onClick: ()=>{alert('click')}}]
-map.pm.Toolbar.createCustomControl({name:"Polygon2",tool: "custom",className:"leaflet-pm-icon-polygon",title: "Display text on hover button",afterClick: afterClick, actions: actions});
-
-//Custom action
-var circle = map.pm.Draw.createNewDrawInstance("Circle2","Circle");
-circle.setPathOptions({color :'green'});
-var afterClick = () => {
-    circle.toggle();
-};
-var act = {
-    text: 'Custom action',
-    onClick(e){
-        alert('click')
-    }
-};
-var actions2 = [act,'cancel'];
-map.pm.Toolbar.createCustomControl({name:"Circle2",tool: "custom",className:"leaflet-pm-icon-circle",title: "Display text on hover button",afterClick: afterClick,actions: actions2});
+map.pm.Toolbar.createCustomControl({name:"alertBox",block: "custom",className: "leaflet-pm-icon-marker",title: "Count layers",onClick: ()=>{alert("There are "+L.PM.Utils.findLayers(map).length+" layers on the map")},toggle: false});
 
 
-//Add to edit container
-var rectangle = map.pm.Draw.createNewDrawInstance("Rectangle2","Rectangle");
-var afterClick = () => {
-    rectangle.toggle();
-};
-var container = "edit";
-var actions3 = ['cancel'];
-map.pm.Toolbar.createCustomControl({name:"Rectangle2",tool: container,className:"leaflet-pm-icon-rectangle",title: "Display text on hover button",afterClick: afterClick,actions: actions3});
+// Copy Geoman Draw Control
+const _actions = [{text: "Custom message, with click event",onClick(e){alert('click');}}];
+map.pm.Toolbar.copyDrawControl("Rectangle", {name:"RectangleCopy",block: "custom",title: "Display text on hover button",actions: _actions});
+map.pm.Draw.RectangleCopy.setPathOptions({color :'green'});
 
-rectangle.setPathOptions({color :'orange'});
-
-//Show message
-var rectangle3 = map.pm.Draw.createNewDrawInstance("Rectangle3","Rectangle");
-var afterClick = () => {
-    rectangle3.toggle();
-};
-var actions4 = [{text: "Custom message, no click event"}];
-map.pm.Toolbar.createCustomControl({name:"Rectangle3",tool: "custom",className:"leaflet-pm-icon-rectangle",title: "Display text on hover button",afterClick: afterClick,actions: actions4});
-
-map.pm.Toolbar.changeControlOrder(["Rectangle3"])
-rectangle3.setPathOptions({color :'green'});
-
-
-
-
+map.pm.Toolbar.changeControlOrder(["RectangleCopy"])
 
 

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -40,3 +40,20 @@ h3 {
 .map {
     height: 500px;
 }
+
+
+.leaflet-control-container > div.leaflet-top.leaflet-left {
+    height: 500px;
+    display: flex;
+    flex-flow: column wrap;
+}
+
+.leaflet-bar{
+    width: 30px;
+}
+
+
+.leaflet-pm-toolbar.activeChild{
+    z-index: 801;
+}
+

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -41,19 +41,3 @@ h3 {
     height: 500px;
 }
 
-
-.leaflet-control-container > div.leaflet-top.leaflet-left {
-    height: 500px;
-    display: flex;
-    flex-flow: column wrap;
-}
-
-.leaflet-bar{
-    width: 30px;
-}
-
-
-.leaflet-pm-toolbar.activeChild{
-    z-index: 801;
-}
-

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -1,5 +1,5 @@
 .leaflet-pm-toolbar {
-  
+
 }
 
 .leaflet-pm-toolbar .leaflet-buttons-control-button {
@@ -116,3 +116,9 @@
   cursor: pointer;
   background-color: #777;
 }
+
+/* That the active control is always over the other controls */
+.leaflet-pm-toolbar.activeChild{
+  z-index: 801;
+}
+

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -9,12 +9,24 @@
   z-index: 3;
 }
 
-.leaflet-pm-toolbar a:first-child:not(.pos-right) {
+.leaflet-pm-toolbar .leaflet-pm-actions-container a:first-child:not(.pos-right) {
   border-radius: 0 !important;
 }
 
-.leaflet-pm-toolbar a:last-child.pos-right {
+.leaflet-pm-toolbar .leaflet-pm-actions-container a:last-child.pos-right {
   border-radius: 0 !important;
+}
+
+.leaflet-pm-toolbar .button-container .leaflet-buttons-control-button {
+  border-radius: 0 !important;
+}
+
+.leaflet-pm-toolbar .button-container:last-child .leaflet-buttons-control-button {
+  border-radius: 0 0 2px 2px !important;
+}
+
+.leaflet-pm-toolbar .button-container:first-child .leaflet-buttons-control-button {
+  border-radius: 2px 2px 0 0 !important;
 }
 
 .leaflet-pm-toolbar .control-fa-icon {

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -70,6 +70,21 @@ const Draw = L.Class.extend({
       this[shape].addButton();
     });
   },
+  createNewDrawInstance(name,jsClass) {
+    if(this[name]){
+      throw "Draw Type already exists";
+    }
+    if(!L.PM.Draw[jsClass]){
+      throw "There is no class L.PM.Draw."+jsClass;
+    }
+
+    this[name] = new L.PM.Draw[jsClass](this._map);
+    this[name].toolbarButtonName  = name;
+    this.shapes.push(name);
+    // Re-init the options, so it is not referenced with the default Draw class
+    this[name].setOptions(this[name].options);
+    return this[name];
+  }
 });
 
 export default Draw;

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -72,10 +72,14 @@ const Draw = L.Class.extend({
   },
   createNewDrawInstance(name,jsClass) {
     if(this[name]){
-      throw "Draw Type already exists";
+      throw new TypeError(
+        "Draw Type already exists"
+      );
     }
     if(!L.PM.Draw[jsClass]){
-      throw "There is no class L.PM.Draw."+jsClass;
+      throw new TypeError(
+        `There is no class L.PM.Draw.${jsClass}`
+      );
     }
 
     this[name] = new L.PM.Draw[jsClass](this._map);

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -72,7 +72,7 @@ const Draw = L.Class.extend({
   },
   getActiveShape(){
     // returns the active shape
-    var enabledShape = undefined;
+    let enabledShape;
     this.shapes.forEach(shape => {
       if(this[shape]._enabled){
         enabledShape = shape;
@@ -97,23 +97,49 @@ const Draw = L.Class.extend({
   },
 
   createNewDrawInstance(name,jsClass) {
+    const instance = this._getShapeFromBtnName(jsClass);
     if(this[name]){
       throw new TypeError(
         "Draw Type already exists"
       );
     }
-    if(!L.PM.Draw[jsClass]){
+    if(!L.PM.Draw[instance]){
       throw new TypeError(
-        `There is no class L.PM.Draw.${jsClass}`
+        `There is no class L.PM.Draw.${instance}`
       );
     }
 
-    this[name] = new L.PM.Draw[jsClass](this._map);
+    this[name] = new L.PM.Draw[instance](this._map);
     this[name].toolbarButtonName  = name;
     this.shapes.push(name);
+
+    // needed when extended / copied from a custom instance
+    if(this[jsClass]) {
+      this[name].setOptions(this[jsClass].options);
+    }
     // Re-init the options, so it is not referenced with the default Draw class
     this[name].setOptions(this[name].options);
+
     return this[name];
+  },
+  _getShapeFromBtnName(name){
+    const shapeMapping = {
+      "drawMarker": "Marker",
+      "drawCircle": "Circle",
+      "drawPolygon": "Polygon",
+      "drawPolyline": "Line",
+      "drawRectangle": "Rectangle",
+      "drawCircleMarker": "CircleMarker",
+      "editMode": "Edit",
+      "dragMode": "Drag",
+      "cutPoylgon": "Cut",
+      "removalMode": "Removal"
+    };
+
+    if(shapeMapping[name]){
+      return shapeMapping[name];
+    }
+    return this[name] ? this[name]._shape : name;
   }
 });
 

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -60,7 +60,7 @@ const Map = L.Class.extend({
   },
   setPathOptions(options, ignore = []) {
     this.map.pm.Draw.shapes.forEach(shape => {
-      if(ignore.indexOf(shape) == -1) {
+      if(ignore.indexOf(shape) === -1) {
         this.map.pm.Draw[shape].setPathOptions(options)
       }
     })

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -58,8 +58,12 @@ const Map = L.Class.extend({
 
     this.Draw.disable(shape);
   },
-  setPathOptions(options) {
-    this.Draw.setPathOptions(options);
+  setPathOptions(options, ignore = []) {
+    this.map.pm.Draw.shapes.forEach(shape => {
+      if(ignore.indexOf(shape) == -1) {
+        this.map.pm.Draw[shape].setPathOptions(options)
+      }
+    })
   },
 
   getGlobalOptions() {
@@ -97,6 +101,7 @@ const Map = L.Class.extend({
       }
     });
   },
+
 });
 
 export default Map;

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -65,7 +65,10 @@ const Map = L.Class.extend({
 
     this.Draw.disable(shape);
   },
-  setPathOptions(options, ignore = []) {
+  // optionsModifier for spezial options like ignoreShapes
+  setPathOptions(options, optionsModifier = {}) {
+    const ignore = optionsModifier.ignoreShapes || [];
+
     this.map.pm.Draw.shapes.forEach(shape => {
       if(ignore.indexOf(shape) === -1) {
         this.map.pm.Draw[shape].setPathOptions(options)

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -12,11 +12,17 @@ const PMButton = L.Control.extend({
   onAdd(map) {
     this._map = map;
 
-    if (this._button.tool === 'edit') {
-      this._container = this._map.pm.Toolbar.editContainer;
-    } else if (this._button.tool === 'options') {
-      this._container = this._map.pm.Toolbar.optionsContainer;
-    } else {
+    if(!this._map.pm.Toolbar.options.oneBlock) {
+      if (this._button.tool === 'edit') {
+        this._container = this._map.pm.Toolbar.editContainer;
+      } else if (this._button.tool === 'options') {
+        this._container = this._map.pm.Toolbar.optionsContainer;
+      } else if (this._button.tool === 'custom') {
+        this._container = this._map.pm.Toolbar.customContainer;
+      } else {
+        this._container = this._map.pm.Toolbar.drawContainer;
+      }
+    }else{
       this._container = this._map.pm.Toolbar.drawContainer;
     }
     this.buttonsDomNode = this._makeButton(this._button);
@@ -112,7 +118,13 @@ const PMButton = L.Control.extend({
     };
 
     activeActions.forEach(name => {
-      const action = actions[name];
+      if(actions[name]) {
+        var action = actions[name];
+      }else if(name.text){
+        var action = name;
+      }else{
+        return;
+      }
       const actionNode = L.DomUtil.create(
         'a',
         `leaflet-pm-action action-${name}`,
@@ -121,7 +133,9 @@ const PMButton = L.Control.extend({
 
       actionNode.innerHTML = action.text;
 
-      L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
+      if(action.onClick) {
+        L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
+      }
       L.DomEvent.disableClickPropagation(actionNode);
     });
 
@@ -159,10 +173,12 @@ const PMButton = L.Control.extend({
       return;
     }
 
-    if (!this._button.toggleStatus) {
+    if (!this._button.toggleStatus || this._button.cssToggle === false) {
       L.DomUtil.removeClass(this.buttonsDomNode, 'active');
+      L.DomUtil.removeClass(this._container, 'activeChild');
     } else {
       L.DomUtil.addClass(this.buttonsDomNode, 'active');
+      L.DomUtil.addClass(this._container, 'activeChild');
     }
   },
 

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -11,7 +11,6 @@ const PMButton = L.Control.extend({
   },
   onAdd(map) {
     this._map = map;
-
     if(!this._map.pm.Toolbar.options.oneBlock) {
       if (this._button.tool === 'edit') {
         this._container = this._map.pm.Toolbar.editContainer;
@@ -62,12 +61,13 @@ const PMButton = L.Control.extend({
     this.toggle(false);
   },
   _triggerClick(e) {
-    this._button.onClick(e);
+    // TODO is this a big change when we change from e to a object with the event and the button? Now it's the second argument
+    this._button.onClick(e,{button: this, event: e});
     this._clicked(e);
-    this._button.afterClick(e);
+    this._button.afterClick(e,{button: this, event: e});
   },
   _makeButton(button) {
-    var pos = this.options.position.indexOf("right") > -1 ? "pos-right" : "";
+    const pos = this.options.position.indexOf("right") > -1 ? "pos-right" : "";
 
     // button container
     const buttonContainer = L.DomUtil.create(
@@ -86,7 +86,7 @@ const PMButton = L.Control.extend({
     // the buttons actions
     const actionContainer = L.DomUtil.create(
       'div',
-      'leaflet-pm-actions-container '+pos,
+      `leaflet-pm-actions-container ${pos}`,
       buttonContainer
     );
 
@@ -120,10 +120,11 @@ const PMButton = L.Control.extend({
     };
 
     activeActions.forEach(name => {
+      let action;
       if(actions[name]) {
-        var action = actions[name];
+        action = actions[name];
       }else if(name.text){
-        var action = name;
+        action = name;
       }else{
         return;
       }

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -441,12 +441,13 @@ const Toolbar = L.Class.extend({
     this.changeControlOrder();
   },
 
-  changeControlOrder(_order = []){
+  changeControlOrder(order = []){
 
     const shapeMapping = {
       "Marker": "drawMarker",
       "Circle": "drawCircle",
       "Polygon": "drawPolygon",
+      "Rectangle": "drawRectangle",
       "Polyline": "drawPolyline",
       "Line": "drawPolyline",
       "CircleMarker": "drawCircleMarker",
@@ -456,12 +457,12 @@ const Toolbar = L.Class.extend({
       "Removal": "removalMode"
     };
 
-    const order = [];
-    _order.forEach((shape)=>{
+    const _order = [];
+    order.forEach((shape)=>{
       if(shapeMapping[shape]){
-        order.push(shapeMapping[shape]);
+        _order.push(shapeMapping[shape]);
       }else{
-        order.push(shape);
+        _order.push(shape);
       }
     });
 
@@ -471,7 +472,7 @@ const Toolbar = L.Class.extend({
 
     // This steps are needed to create a new Object which contains the buttons in the correct sorted order.
     const newbtnorder = {};
-    order.forEach((control)=>{
+    _order.forEach((control)=>{
       if(buttons[control]) {
         newbtnorder[control] = buttons[control];
       }
@@ -479,31 +480,31 @@ const Toolbar = L.Class.extend({
 
     const drawBtns = Object.keys(buttons).filter(btn => !buttons[btn]._button.tool);
     drawBtns.forEach((btn)=>{
-      if(order.indexOf(btn) === -1) {
+      if(_order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
     const editBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "edit");
     editBtns.forEach((btn)=>{
-      if(order.indexOf(btn) === -1) {
+      if(_order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
     const optionsBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "options");
     optionsBtns.forEach((btn)=>{
-      if(order.indexOf(btn) === -1) {
+      if(_order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
     const customBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "custom");
     customBtns.forEach((btn)=>{
-      if(order.indexOf(btn) === -1) {
+      if(_order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
     // To add all other buttons they are not in a container from above (maybe added manually by a developer)
     Object.keys(buttons).forEach((btn)=>{
-      if(order.indexOf(btn) === -1) {
+      if(_order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -145,7 +145,7 @@ const Toolbar = L.Class.extend({
     // the options toolbar should not be disabled during the different modes
     // TODO: probably need to abstract this a bit so different options are automatically
     // disabled for different modes, like pinning for circles
-    var exceptOptionButtons = ['snappingOption']
+    const exceptOptionButtons = ['snappingOption']
 
     for (const name in this.buttons) {
       if (
@@ -174,6 +174,10 @@ const Toolbar = L.Class.extend({
     // to disable their mode
     if (disableOthers) {
       this.triggerClickOnToggledButtons(this.buttons[name]);
+    }
+
+    if(!this.buttons[name]){
+      return false;
     }
     // now toggle the state of the button
     return this.buttons[name].toggle(status);
@@ -359,8 +363,8 @@ const Toolbar = L.Class.extend({
     // different options so it's basically a reset and add again
     this.removeControls();
 
-    var buttons = this.getButtons();
-    var ignoreBtns = [];
+    const buttons = this.getButtons();
+    let ignoreBtns = [];
 
     if(this.options.drawControls === false){
       ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => !buttons[btn]._button.tool));
@@ -383,8 +387,8 @@ const Toolbar = L.Class.extend({
     }
   },
 
-  //createCustomButton(name,tool,className,title, onClick, afterClick, actions, toggle){
-  createCustomButton(options){
+  // createCustomControl(name,tool,className,title, onClick, afterClick, actions, toggle){
+  createCustomControl(options){
 
     if(!options.name){
       throw "Button has no name";
@@ -406,13 +410,13 @@ const Toolbar = L.Class.extend({
     if(options.tool) {
       options.tool = options.tool.toLowerCase();
     }
-    if (!options.tool || options.tool == "draw") {
+    if (!options.tool || options.tool === "draw") {
       options.tool = "";
     }
 
-    var _options = {
+    const _options = {
       tool: options.tool,
-      className: 'control-icon '+options.className,
+      className: `control-icon ${options.className}`,
       title: options.title || '',
       jsClass: options.name,
       onClick: options.onClick,
@@ -434,10 +438,8 @@ const Toolbar = L.Class.extend({
   },
 
   changeControlOrder(_order = []){
-   // order = ["drawCircle","dragMode","drawMarker","removalMode","xxx","xyz"];
-   // var buttons = ["drawMarker","drawPolyline","drawRectangle","drawPolygon","drawCircle","drawCircleMarker","editMode","dragMode","cutPolygon","removalMode"];
 
-    var shapeMapping = {
+    const shapeMapping = {
       "Marker": "drawMarker",
       "Circle": "drawCircle",
       "Polygon": "drawPolygon",
@@ -450,7 +452,7 @@ const Toolbar = L.Class.extend({
       "Removal": "removalMode"
     };
 
-    var order = [];
+    const order = [];
     _order.forEach((shape)=>{
       if(shapeMapping[shape]){
         order.push(shapeMapping[shape]);
@@ -461,35 +463,35 @@ const Toolbar = L.Class.extend({
 
 
 
-    var buttons = this.getButtons();
+    const buttons = this.getButtons();
 
     // This steps are needed to create a new Object which contains the buttons in the correct sorted order.
-    var newbtnorder = {};
+    const newbtnorder = {};
     order.forEach((control)=>{
       if(buttons[control]) {
         newbtnorder[control] = buttons[control];
       }
     });
 
-    var drawBtns = Object.keys(buttons).filter(btn => !buttons[btn]._button.tool);
+    const drawBtns = Object.keys(buttons).filter(btn => !buttons[btn]._button.tool);
     drawBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
-    var editBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "edit");
+    const editBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "edit");
     editBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
-    var optionsBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "options");
+    const optionsBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "options");
     optionsBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
-    var customBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "custom");
+    const customBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "custom");
     customBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
@@ -506,9 +508,9 @@ const Toolbar = L.Class.extend({
     this._showHideButtons();
   },
   getControlOrder(){
-    var buttons = this.getButtons();
+    const buttons = this.getButtons();
 
-    var shapeMapping = {
+    const shapeMapping = {
       "drawMarker": "Marker",
       "drawCircle": "Circle",
       "drawPolygon": "Polygon",
@@ -520,8 +522,8 @@ const Toolbar = L.Class.extend({
       "removalMode": "Removal"
     };
 
-    var order = [];
-    for(var btn in buttons){
+    const order = [];
+    for(const btn in buttons){
       if(shapeMapping[btn]){
         order.push(shapeMapping[btn])
       }else{

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -370,13 +370,13 @@ const Toolbar = L.Class.extend({
       ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => !buttons[btn]._button.tool));
     }
     if(this.options.editControls === false){
-      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool == 'edit'));
+      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool === 'edit'));
     }
     if(this.options.optionsControls === false){
-      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool == 'options'));
+      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool === 'options'));
     }
     if(this.options.customControls === false){
-      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool == 'custom'));
+      ignoreBtns = ignoreBtns.concat(Object.keys(buttons).filter(btn => buttons[btn]._button.tool === 'custom'));
     }
     for (const btn in buttons) {
       if (this.options[btn] && ignoreBtns.indexOf(btn) === -1) {
@@ -391,11 +391,15 @@ const Toolbar = L.Class.extend({
   createCustomControl(options){
 
     if(!options.name){
-      throw "Button has no name";
+      throw new TypeError(
+        "Button has no name"
+      );
     }
 
     if(this.buttons[options.name]){
-      throw "Button with this name already exists";
+      throw new TypeError(
+        "Button with this name already exists"
+      )
     }
     if(!options.onClick){
       options.onClick = () => {};
@@ -479,19 +483,19 @@ const Toolbar = L.Class.extend({
         newbtnorder[btn] = buttons[btn];
       }
     });
-    const editBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "edit");
+    const editBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "edit");
     editBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
-    const optionsBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "options");
+    const optionsBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "options");
     optionsBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];
       }
     });
-    const customBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool == "custom");
+    const customBtns = Object.keys(buttons).filter(btn => buttons[btn]._button.tool === "custom");
     customBtns.forEach((btn)=>{
       if(order.indexOf(btn) === -1) {
         newbtnorder[btn] = buttons[btn];


### PR DESCRIPTION
With this PR it is possible to add custom Controls to the Toolbar, with own actions.
Also multiple Draw Instances can be created.

Maybe it needs a few changes, but I want to talk with you about that.

Also this would be your part @codeofsumit to rewrite the sentences in the Readme, for better understanding.

Nice to know:
With that css a Toolbar with position `topleft` is automatically displayed in a new row if it goes out of the map border.
```
.leaflet-control-container > div.leaflet-top.leaflet-left {
    height: 500px;  /* map height */
    display: flex;
    flex-flow: column wrap;
}
```
But I don't know if this should be in the Readme.

Will fix #614 