### PR TITLE
Cut edit event

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,15 +478,16 @@ The following methods are available on `map.pm`:
 
 The following events are available on a layer instance:
 
-| Event  | Params | Description                    | Output                              |
-| :----- | :----- | :----------------------------- | :---------------------------------- |
-| pm:cut | `e`    | Fired when the layer being cut | `shape`, `layer`, `originalLayer`   |
+| Event   | Params | Description                        | Output                              |
+| :------ | :----- | :--------------------------------- | :---------------------------------- |
+| pm:cut  | `e`    | Fired when the layer being cut     | `shape`, `layer`, `originalLayer`   |
+| pm:edit | `e`    | Fired when a layer is edited / cut | `layer`                             |
 
 The following events are available on a map instance:
 
 | Event                    | Params | Description                        | Output                            |
 | :----------------------- | :----- | :--------------------------------- | :-------------------------------- |
-| pm:globaldrawmodetoggled | `e`    | Fired when Drawing Mode is toggled | `enabled`, `map`                  | 
+| pm:globalcutmodetoggled  | `e`    | Fired when Cutting Mode is toggled | `enabled`, `map`                  | 
 | pm:cut                   | `e`    | Fired when any layer is being cut  | `shape`, `layer`, `originalLayer` |
 
 ### Options

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -74,10 +74,12 @@ Draw.Cut = Draw.Polygon.extend({
         layer: resultingLayer,
         originalLayer: l,
       });
+      this._editedLayers.push(l);
 
     });
   },
   _finishShape() {
+    this._editedLayers = [];
     // if self intersection is not allowed, do not finish the shape!
     if (!this.options.allowSelfIntersection) {
       this._handleSelfIntersection(false);
@@ -100,5 +102,11 @@ Draw.Cut = Draw.Polygon.extend({
     // remove the first vertex from "other snapping layers"
     this._otherSnapLayers.splice(this._tempSnapLayerIndex, 1);
     delete this._tempSnapLayerIndex;
+
+    this._editedLayers.forEach((layer) =>{
+      // fire edit event after cut is disabled
+      layer.fire('pm:edit', { layer});
+    });
+    this._editedLayers = [];
   },
 });

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -61,20 +61,10 @@ Draw.Cut = Draw.Polygon.extend({
         this._map.pm.removeLayer({ target: resultingLayer });
       }
 
-      // fire pm:cut on the cutted layer
-      l.fire('pm:cut', {
-        shape: this._shape,
+      this._editedLayers.push({
         layer: resultingLayer,
-        originalLayer: l,
+        originalLayer: l
       });
-
-      // fire pm:cut on the map
-      this._map.fire('pm:cut', {
-        shape: this._shape,
-        layer: resultingLayer,
-        originalLayer: l,
-      });
-      this._editedLayers.push(l);
 
     });
   },
@@ -103,9 +93,23 @@ Draw.Cut = Draw.Polygon.extend({
     this._otherSnapLayers.splice(this._tempSnapLayerIndex, 1);
     delete this._tempSnapLayerIndex;
 
-    this._editedLayers.forEach((layer) =>{
-      // fire edit event after cut is disabled
-      layer.fire('pm:edit', { layer});
+    this._editedLayers.forEach(({layer, originalLayer}) =>{
+      // fire pm:cut on the cutted layer
+      originalLayer.fire('pm:cut', {
+        shape: this._shape,
+        layer,
+        originalLayer,
+      });
+
+      // fire pm:cut on the map
+      this._map.fire('pm:cut', {
+        shape: this._shape,
+        layer,
+        originalLayer,
+      });
+
+      // fire edit event after cut
+      originalLayer.fire('pm:edit', { layer: originalLayer});
     });
     this._editedLayers = [];
   },


### PR DESCRIPTION
Fires `pm:edit` event on the original cutted layer after cut is disabled

Fix #619 