### PR TITLE
Fix bug when circle is the only layer on the map

### DIFF
--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -6,6 +6,8 @@ Edit.Circle = Edit.extend({
   initialize(layer) {
     this._layer = layer;
     this._enabled = false;
+    // create polygon around the circle border
+    this._updateHiddenPolyCircle();
   },
   applyOptions() {
     if (this.options.snappable) {

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -6,6 +6,8 @@ Edit.CircleMarker = Edit.extend({
   initialize(layer) {
     this._layer = layer;
     this._enabled = false;
+    // create polygon around the circle border
+    this._updateHiddenPolyCircle();
   },
   applyOptions() {
     // Use the not editable and only draggable version
@@ -285,21 +287,24 @@ Edit.CircleMarker = Edit.extend({
     marker.off('pm:dragstart', this._unsnap, this);
   },
   _updateHiddenPolyCircle() {
-    const pointA = this._layer._map.project(this._layer.getLatLng());
-    const pointB = L.point(pointA.x + this._layer.getRadius(), pointA.y);
-    const radius = this._layer.getLatLng().distanceTo(this._layer._map.unproject(pointB));
+    const map = this._layer._map || this._map;
+    if(map) {
+      const pointA = map.project(this._layer.getLatLng());
+      const pointB = L.point(pointA.x + this._layer.getRadius(), pointA.y);
+      const radius = this._layer.getLatLng().distanceTo(map.unproject(pointB));
 
-    const _layer = L.circle(this._layer.getLatLng(), this._layer.options);
-    _layer.setRadius(radius);
+      const _layer = L.circle(this._layer.getLatLng(), this._layer.options);
+      _layer.setRadius(radius);
 
-    if (this._hiddenPolyCircle) {
-      this._hiddenPolyCircle.setLatLngs(Utils.circleToPolygon(_layer, 200).getLatLngs());
-    } else {
-      this._hiddenPolyCircle = Utils.circleToPolygon(_layer, 200);
-    }
+      if (this._hiddenPolyCircle) {
+        this._hiddenPolyCircle.setLatLngs(Utils.circleToPolygon(_layer, 200).getLatLngs());
+      } else {
+        this._hiddenPolyCircle = Utils.circleToPolygon(_layer, 200);
+      }
 
-    if (!this._hiddenPolyCircle._parentCopy) {
-      this._hiddenPolyCircle._parentCopy = this._layer
+      if (!this._hiddenPolyCircle._parentCopy) {
+        this._hiddenPolyCircle._parentCopy = this._layer
+      }
     }
   }
 });

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -92,6 +92,11 @@ const DragMixin = {
       return false;
     }
 
+    // update the hidden circle border after dragging
+    if(this._layer instanceof L.CircleMarker){
+      this._layer.pm._updateHiddenPolyCircle();
+    }
+
     // timeout to prevent click event after drag :-/
     // TODO: do it better as soon as leaflet has a way to do it better :-)
     window.setTimeout(() => {

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -165,9 +165,6 @@ const SnapMixin = {
   // we got the point we want to snap to (C), but we need to check if a coord of the polygon
   // receives priority over C as the snapping point. Let's check this here
   _checkPrioritiySnapping(closestLayer) {
-    if(!closestLayer){
-      return {};
-    }
     const map = this._map;
 
     // A and B are the points of the closest segment to P (the marker position we want to snap)

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -90,6 +90,11 @@ const SnapMixin = {
       this._snapList
     );
 
+    // if no layers found. Can happen when circle is the only visible layer on the map and the hidden snapping-border circle layer is also on the map
+    if(Object.keys(closestLayer).length === 0){
+      return false;
+    }
+
     const isMarker =
       closestLayer.layer instanceof L.Marker ||
       closestLayer.layer instanceof L.CircleMarker;
@@ -160,6 +165,9 @@ const SnapMixin = {
   // we got the point we want to snap to (C), but we need to check if a coord of the polygon
   // receives priority over C as the snapping point. Let's check this here
   _checkPrioritiySnapping(closestLayer) {
+    if(!closestLayer){
+      return {};
+    }
     const map = this._map;
 
     // A and B are the points of the closest segment to P (the marker position we want to snap)


### PR DESCRIPTION
When circle was the only layer on the map, the hidden snapping-border circle was making problems while edit mode.

Fix: #640
Fix: #652