### PR TITLE
Fix finishOn dblclick bug

### DIFF
--- a/cypress/integration/polygon.spec.js
+++ b/cypress/integration/polygon.spec.js
@@ -212,6 +212,27 @@ describe('Draw & Edit Poly', () => {
     cy.toolbarButton('edit').click();
   });
 
+  it('create vertex when dblclick', () => {
+    cy.window().then(({ map }) => {
+      map.pm.enableDraw('Polygon', {
+        allowSelfIntersection: false,
+        finishOn: 'dblclick',
+      });
+    });
+
+    cy.get(mapSelector)
+      .click(90, 250)
+      .click(100, 50)
+      .click(150, 50)
+      .dblclick(150, 150);
+
+    cy.toolbarButton('edit').click();
+
+    cy.hasVertexMarkers(4);
+
+    cy.toolbarButton('edit').click();
+  });
+
   it('prevent creation while self intersection', () => {
 
     cy.window().then(({ map }) => {

--- a/src/js/Draw/L.PM.Draw.Polygon.js
+++ b/src/js/Draw/L.PM.Draw.Polygon.js
@@ -27,11 +27,6 @@ Draw.Polygon = Draw.Line.extend({
       return;
     }
 
-    // create the leaflet shape and add it to the map
-    if (e && e.type === 'dblclick') {
-      // Leaflet creates an extra node with double click
-      coords.splice(coords.length - 1, 1);
-    }
     const polygonLayer = L.polygon(coords, this.options.pathOptions).addTo(
       this._map
     );


### PR DESCRIPTION
Because of the PR https://github.com/geoman-io/leaflet-geoman/pull/621 no vertex is created when finished with `dblclick`.

Reference #631 