### PR TITLE
Replace difference and intersection from turf

### DIFF
--- a/cypress/integration/rectangle.spec.js
+++ b/cypress/integration/rectangle.spec.js
@@ -67,4 +67,35 @@ describe('Draw Rectangle', () => {
       expect(marker.options.draggable).to.equal(false);
     });
   });
+
+  it('Multiple Cuts', ()=>{
+    cy.toolbarButton('rectangle').click();
+    cy.get(mapSelector)
+      .click(191,216)
+      .click(608,323);
+
+    cy.toolbarButton('cut').click();
+    cy.get(mapSelector)
+      .click(226,389)
+      .click(230,105)
+      .click(270,396)
+      .click(226,389);
+
+    cy.toolbarButton('cut').click();
+    cy.get(mapSelector)
+      .click(293,356)
+      .click(293,122)
+      .click(340,367)
+      .click(293,356);
+
+    cy.toolbarButton('cut').click();
+    cy.get(mapSelector)
+      .click(364,345)
+      .click(363,138)
+      .click(414,368)
+      .click(364,345);
+
+    cy.toolbarButton('edit').click();
+    cy.hasVertexMarkers(16);
+  })
 });

--- a/package.json
+++ b/package.json
@@ -19,10 +19,9 @@
   ],
   "main": "dist/leaflet-geoman.min.js",
   "dependencies": {
-    "@turf/difference": "^6.0.2",
-    "@turf/intersect": "^6.1.3",
     "@turf/kinks": "6.x",
     "@turf/line-intersect": "^6.0.2",
+    "polygon-clipping": "^0.15.1",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -1,6 +1,5 @@
-import intersect from '@turf/intersect';
-import difference from '@turf/difference';
 import Draw from './L.PM.Draw';
+import {difference, intersect} from "../helpers/turfHelper";
 
 Draw.Cut = Draw.Polygon.extend({
   initialize(map) {

--- a/src/js/helpers/turfHelper.js
+++ b/src/js/helpers/turfHelper.js
@@ -1,0 +1,56 @@
+import polygonClipping from 'polygon-clipping';
+
+export function feature(geom){
+  const feat = {type: "Feature"};
+  feat.geometry = geom;
+  return feat;
+}
+
+export function getGeometry(geojson) {
+  if(geojson.type === "Feature") return geojson.geometry;
+  return geojson;
+}
+
+export function getCoords(geojson) {
+  return geojson.geometry.coordinates;
+}
+
+export function turfPoint(coords) {
+  return feature({"type": "Point", "coordinates": coords});
+}
+
+export function turfLineString(coords) {
+  return feature({"type": "LineString", "coordinates": coords});
+}
+
+export function turfPolygon(coords) {
+  return feature({"type": "Polygon", "coordinates": coords});
+}
+
+export function turfMultiPolygon(coords) {
+  return feature({"type": "MultiPolygon", "coordinates": coords});
+}
+
+export function turfFeatureCollection(features) {
+  return {type: "FeatureCollection", "features": features};
+}
+
+export function intersect(poly1,poly2) {
+  const geom1 = getGeometry(poly1);
+  const geom2 = getGeometry(poly2);
+
+  const intersection = polygonClipping.intersection(geom1.coordinates,geom2.coordinates);
+  if (intersection.length === 0) return null;
+  if (intersection.length === 1) return turfPolygon(intersection[0]);
+  return turfMultiPolygon(intersection);
+}
+
+export function difference(polygon1, polygon2) {
+  const geom1 = getGeometry(polygon1);
+  const geom2 = getGeometry(polygon2);
+
+  const differenced = polygonClipping.difference(geom1.coordinates, geom2.coordinates);
+  if (differenced.length === 0) return null;
+  if (differenced.length === 1) return turfPolygon(differenced[0]);
+  return turfMultiPolygon(differenced);
+}


### PR DESCRIPTION
Replace difference and intersection from turf with the new lib `polygon-clipping`. This lib is also used in the alpha version of turf but turf make problems ... so why not use the original source?

Fix: #630 