### PR TITLE
Shape fix in events

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,19 +321,19 @@ The following events are available on a layer instance:
 
 | Event              | Params | Description                                                                                          | Output                                                                                                  |
 | :----------------- | :----- | :--------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
-| pm:edit            | `e`    | Fired when a layer is edited.                                                                        | `layer`                                                                                                 |
-| pm:update          | `e`    | Fired when edit mode is disabled and a layer is edited and its coordinates have changed.             | `layer`                                                                                                 |
-| pm:enable          | `e`    | Fired when edit mode on a layer is enabled                                                           | `layer`                                                                                                 |
-| pm:disable         | `e`    | Fired when edit mode on a layer is disabled                                                          | `layer`                                                                                                 |
-| pm:vertexadded     | `e`    | Fired when a vertex is added                                                                         | `layer`, `indexPath`, `latlng`, `marker`                                                                |
-| pm:vertexremoved   | `e`    | Fired when a vertex is removed                                                                       | `layer`, `indexPath`, `marker`                                                                          |
-| pm:markerdragstart | `e`    | Fired when dragging of a marker which corresponds to a vertex starts                                 | `layer`, `indexPath`, `markerEvent`                                                                     |
-| pm:markerdragend   | `e`    | Fired when dragging of a vertex-marker ends                                                          | `layer`, `indexPath`, `markerEvent`                                                                     |
+| pm:edit            | `e`    | Fired when a layer is edited.                                                                        | `layer`, `shape`                                                                                                 |
+| pm:update          | `e`    | Fired when edit mode is disabled and a layer is edited and its coordinates have changed.             | `layer`, `shape`                                                                                                 |
+| pm:enable          | `e`    | Fired when edit mode on a layer is enabled                                                           | `layer`, `shape`                                                                                                 |
+| pm:disable         | `e`    | Fired when edit mode on a layer is disabled                                                          | `layer`, `shape`                                                                                                 |
+| pm:vertexadded     | `e`    | Fired when a vertex is added                                                                         | `layer`, `indexPath`, `latlng`, `marker`, `shape`                                                                |
+| pm:vertexremoved   | `e`    | Fired when a vertex is removed                                                                       | `layer`, `indexPath`, `marker`, `shape`                                                                          |
+| pm:markerdragstart | `e`    | Fired when dragging of a marker which corresponds to a vertex starts                                 | `layer`, `indexPath`, `markerEvent`, `shape`                                                                     |
+| pm:markerdragend   | `e`    | Fired when dragging of a vertex-marker ends                                                          | `layer`, `indexPath`, `markerEvent`, `shape`                                                                     |
 | pm:snapdrag        | `e`    | Fired during a marker move/drag. Payload includes info about involved layers and snapping calculation| `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:snap            | `e`    | Fired when a vertex-marker is snapped to another vertex. Also fired on the marker itself.            | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:unsnap          | `e`    | Fired when a vertex-marker is unsnapped from a vertex. Also fired on the marker itself.              | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
-| pm:intersect       | `e`    | When `allowSelfIntersection: false`, this event is fired as soon as a self-intersection is detected. | `layer`, `intersection`                                                                                 |
-| pm:centerplaced    | `e`    | Fired when the center of a circle is moved                                                           | `layer`, `latlng`                                                                                       |
+| pm:intersect       | `e`    | When `allowSelfIntersection: false`, this event is fired as soon as a self-intersection is detected. | `layer`, `intersection`, `shape`                                                                                 |
+| pm:centerplaced    | `e`    | Fired when the center of a circle is moved                                                           | `layer`, `latlng`, `shape`                                                                                       |
 
 You can enable Edit Mode for all layers on a map like this:
 
@@ -386,11 +386,11 @@ The following methods are available on `map.pm`:
 
 The following events are available on a layer instance:
 
-| Event        | Params | Description                              | Output                                                           |
-| :----------- | :----- | :--------------------------------------- | :--------------------------------------------------------------- |
-| pm:dragstart | `e`    | Fired when a layer starts being dragged. | `layer`                                                          |
-| pm:drag      | `e`    | Fired when a layer is dragged.           | `layer`, `containerPoint`,`latlng`, `layerPoint`,`originalEvent` |
-| pm:dragend   | `e`    | Fired when a layer stops being dragged.  | `layer`                                                          |
+| Event        | Params | Description                              | Output                                                                    |
+| :----------- | :----- | :--------------------------------------- | :------------------------------------------------------------------------ |
+| pm:dragstart | `e`    | Fired when a layer starts being dragged. | `layer`, `shape`                                                          |
+| pm:drag      | `e`    | Fired when a layer is dragged.           | `layer`, `containerPoint`,`latlng`, `layerPoint`,`originalEvent`, `shape` |
+| pm:dragend   | `e`    | Fired when a layer stops being dragged.  | `layer`, `shape`                                                          |
 
 
 The following events are available on a map instance:
@@ -426,16 +426,16 @@ The following methods are available on `map.pm`:
 
 The following events are available on a layer instance:
 
-| Event       | Params | Description                                              | Output  |
-| :---------- | :----- | :------------------------------------------------------- | :------ |
-| pm:remove   | `e`    | Fired when a layer is removed via Removal Mode           | `layer` |
+| Event       | Params | Description                                              | Output           |
+| :---------- | :----- | :------------------------------------------------------- | :--------------- |
+| pm:remove   | `e`    | Fired when a layer is removed via Removal Mode           | `layer`, `shape` |
 
 The following events are available on a map instance:
 
 | Event                         | Params | Description                                              | Output            |
 | :---------------------------- | :----- | :------------------------------------------------------- | :---------------- |
 | pm:globalremovalmodetoggled   | `e`    | Fired when Removal Mode is toggled                       | `enabled`, `map`  |
-| pm:remove                     | `e`    | Fired when a layer is removed via Removal Mode           | `layer`           |
+| pm:remove                     | `e`    | Fired when a layer is removed via Removal Mode           | `layer`, `shape`  |
 | layerremove                   | `e`    | Standard Leaflet event. Fired when any layer is removed. | `layer`           |
 
 You can also listen to specific removal mode events on the map instance like this:
@@ -483,7 +483,7 @@ The following events are available on a layer instance:
 | Event   | Params | Description                        | Output                              |
 | :------ | :----- | :--------------------------------- | :---------------------------------- |
 | pm:cut  | `e`    | Fired when the layer being cut     | `shape`, `layer`, `originalLayer`   |
-| pm:edit | `e`    | Fired when a layer is edited / cut | `layer`                             |
+| pm:edit | `e`    | Fired when a layer is edited / cut | `layer`, `shape`                    |
 
 The following events are available on a map instance:
 

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -262,6 +262,7 @@ describe('Testing the Toolbar', () => {
         cy.window().then(() => {
           map.pm.enableDraw('PolygonCopy');
           map.on('pm:create', (e) => {
+            expect(e.shape).to.equal('PolygonCopy');
             e.layer.on('click', (l) => testlayer = l.target)
           })
         });

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -191,6 +191,7 @@ Draw.Circle = Draw.extend({
       this._layer.fire('pm:centerplaced', {
         workingLayer: this._layer,
         latlng,
+        shape: this._shape
       });
     }
   },
@@ -209,6 +210,7 @@ Draw.Circle = Draw.extend({
 
     // create the final circle layer
     const circleLayer = L.circle(center, options).addTo(this._map);
+    this._setShapeForFinishLayer(circleLayer);
     this._addDrawnLayerProp(circleLayer);
 
     // create polygon around the circle border

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -249,6 +249,7 @@ Draw.CircleMarker = Draw.Marker.extend({
 
     // create marker
     const marker = L.circleMarker(latlng, this.options.pathOptions);
+    this._setShapeForFinishLayer(marker);
     this._addDrawnLayerProp(marker);
     // add marker to the map
     marker.addTo(this._map);
@@ -280,6 +281,7 @@ Draw.CircleMarker = Draw.Marker.extend({
 
     // create the final circle layer
     const circleLayer = L.circleMarker(center, options).addTo(this._map);
+    this._setShapeForFinishLayer(circleLayer);
     this._addDrawnLayerProp(circleLayer);
     // create polygon around the circle border
     circleLayer.pm._updateHiddenPolyCircle();

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -110,7 +110,7 @@ Draw.Cut = Draw.Polygon.extend({
       });
 
       // fire edit event after cut
-      originalLayer.fire('pm:edit', { layer: originalLayer});
+      originalLayer.fire('pm:edit', { layer: originalLayer, shape: originalLayer.pm.getShape()});
     });
     this._editedLayers = [];
   },

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -313,6 +313,7 @@ Draw.Line = Draw.extend({
     const polylineLayer = L.polyline(coords, this.options.pathOptions).addTo(
       this._map
     );
+    this._setShapeForFinishLayer(polylineLayer);
     this._addDrawnLayerProp(polylineLayer);
 
     // disable drawing

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -127,6 +127,7 @@ Draw.Marker = Draw.extend({
 
     // create marker
     const marker = new L.Marker(latlng, this.options.markerStyle);
+    this._setShapeForFinishLayer(marker);
     this._addDrawnLayerProp(marker);
 
     // add marker to the map

--- a/src/js/Draw/L.PM.Draw.Polygon.js
+++ b/src/js/Draw/L.PM.Draw.Polygon.js
@@ -30,6 +30,7 @@ Draw.Polygon = Draw.Line.extend({
     const polygonLayer = L.polygon(coords, this.options.pathOptions).addTo(
       this._map
     );
+    this._setShapeForFinishLayer(polygonLayer);
     this._addDrawnLayerProp(polygonLayer);
 
     // disable drawing

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -241,6 +241,7 @@ Draw.Rectangle = Draw.extend({
     const rectangleLayer = L.rectangle([A, B], this.options.pathOptions).addTo(
       this._map
     );
+    this._setShapeForFinishLayer(rectangleLayer);
     this._addDrawnLayerProp(rectangleLayer);
 
     // disable drawing

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -111,6 +111,7 @@ const Draw = L.Class.extend({
 
     this[name] = new L.PM.Draw[instance](this._map);
     this[name].toolbarButtonName = name;
+    this[name]._shape = name;
     this.shapes.push(name);
 
     // needed when extended / copied from a custom instance
@@ -143,6 +144,9 @@ const Draw = L.Class.extend({
   },
   _addDrawnLayerProp(layer){
     layer._drawnByGeoman = true;
+  },
+  _setShapeForFinishLayer(layer){
+    layer.pm._shape = this._shape;
   }
 });
 

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -57,7 +57,7 @@ Edit.Circle = Edit.extend({
 
     this.applyOptions();
 
-    this._layer.fire('pm:enable', { layer: this._layer });
+    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
 
     // if polygon gets removed from map, disable edit mode
     this._layer.on('remove', e => {
@@ -92,10 +92,10 @@ Edit.Circle = Edit.extend({
     const el = layer._path ? layer._path : this._layer._renderer._container;
     L.DomUtil.removeClass(el, 'leaflet-pm-draggable');
 
-    this._layer.fire('pm:disable', { layer: this._layer });
+    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer });
+      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
 
@@ -152,12 +152,15 @@ Edit.Circle = Edit.extend({
     this._layer.fire('pm:centerplaced', {
       layer: this._layer,
       latlng: center,
+      shape: this.getShape()
     });
   },
   _onMarkerDragStart(e) {
     this._layer.fire('pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
+      shape: this.getShape(),
+      indexPath: undefined
     });
   },
   _onMarkerDragEnd(e) {
@@ -168,6 +171,8 @@ Edit.Circle = Edit.extend({
     this._layer.fire('pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
+      shape: this.getShape(),
+      indexPath: undefined
     });
   },
   _syncCircleRadius() {
@@ -233,17 +238,17 @@ Edit.Circle = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    this._layer.fire('pm:edit', { layer: this._layer });
+    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   _fireDragStart() {
-    this._layer.fire('pm:dragstart');
+    this._layer.fire('pm:dragstart', { layer: this._layer, shape: this.getShape() });
   },
   _fireDrag(e) {
-    this._layer.fire('pm:drag', e);
+    this._layer.fire('pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
-    this._layer.fire('pm:dragend');
+    this._layer.fire('pm:dragend', { layer: this._layer, shape: this.getShape() });
   },
   _updateHiddenPolyCircle() {
     if (this._hiddenPolyCircle) {

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -72,7 +72,7 @@ Edit.CircleMarker = Edit.extend({
     }
     this.applyOptions();
 
-    this._layer.fire('pm:enable', { layer: this._layer });
+    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
     // change state
     this._enabled = true;
 
@@ -106,10 +106,10 @@ Edit.CircleMarker = Edit.extend({
 
     // only fire events if it was enabled before
     if (!this.enabled()) {
-      this._layer.fire('pm:disable', { layer: this._layer });
+      this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
 
       if (this._layerEdited) {
-        this._layer.fire('pm:update', { layer: this._layer });
+        this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
       }
       this._layerEdited = false;
     }
@@ -180,6 +180,7 @@ Edit.CircleMarker = Edit.extend({
     this._layer.fire('pm:centerplaced', {
       layer: this._layer,
       latlng: center,
+      shape: this.getShape()
     });
   },
   _createOuterMarker(latlng) {
@@ -240,25 +241,29 @@ Edit.CircleMarker = Edit.extend({
     if (this.options.editable) {
       this.disable();
     }
-    this._layer.fire('pm:remove');
     this._layer.remove();
-    this._layer.fire('pm:remove', { layer: this._layer });
-    this._map.fire('pm:remove', { layer: this._layer });
+    this._layer.fire('pm:remove', { layer: this._layer, shape: this.getShape() });
+    this._map.fire('pm:remove', { layer: this._layer, shape: this.getShape() });
   },
   _onMarkerDragStart(e) {
     this._layer.fire('pm:markerdragstart', {
       markerEvent: e,
+      layer: this._layer,
+      shape: this.getShape(),
+      indexPath: undefined
     });
   },
   _fireEdit() {
     // fire edit event
-    this._layer.fire('pm:edit', { layer: this._layer });
+    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   _onMarkerDragEnd(e) {
     this._layer.fire('pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
+      shape: this.getShape(),
+      indexPath: undefined
     });
   },
   // _initSnappableMarkers when option editable is not true

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -65,7 +65,7 @@ Edit.Line = Edit.extend({
 
     this.applyOptions();
 
-    this._layer.fire('pm:enable', { layer: this._layer });
+    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
 
     // if polygon gets removed from map, disable edit mode
     this._layer.on('remove', this._onLayerRemove, this);
@@ -121,7 +121,8 @@ Edit.Line = Edit.extend({
     if (!this.options.allowSelfIntersection) {
       this._layer.off(
         'pm:vertexremoved',
-        this._handleSelfIntersectionOnVertexRemoval
+        this._handleSelfIntersectionOnVertexRemoval,
+        this
       );
     }
 
@@ -134,10 +135,10 @@ Edit.Line = Edit.extend({
       L.DomUtil.removeClass(el, 'leaflet-pm-invalid');
     }
 
-    this._layer.fire('pm:disable', { layer: this._layer });
+    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer });
+      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
 
@@ -194,6 +195,7 @@ Edit.Line = Edit.extend({
       this._layer.fire('pm:intersect', {
         layer: this._layer,
         intersection: kinks(this._layer.toGeoJSON(15)),
+        shape: this.getShape()
       });
     } else {
       // if not, reset the style to the default color
@@ -385,6 +387,7 @@ Edit.Line = Edit.extend({
       marker: newM,
       indexPath: this.findDeepMarkerIndex(this._markers, newM).indexPath,
       latlng,
+      shape: this.getShape()
     });
 
     if (this.options.snappable) {
@@ -500,6 +503,7 @@ Edit.Line = Edit.extend({
       layer: this._layer,
       marker,
       indexPath,
+      shape: this.getShape()
       // TODO: maybe add latlng as well?
     });
   },
@@ -645,6 +649,7 @@ Edit.Line = Edit.extend({
       layer: this._layer,
       markerEvent: e,
       indexPath,
+      shape: this.getShape()
     });
 
     // if self intersection is not allowed but this edit caused a self intersection,
@@ -682,6 +687,7 @@ Edit.Line = Edit.extend({
       layer: this._layer,
       markerEvent: e,
       indexPath,
+      shape: this.getShape()
     });
 
     // if self intersection isn't allowed, save the coords upon dragstart
@@ -728,6 +734,6 @@ Edit.Line = Edit.extend({
   _fireEdit() {
     // fire edit event
     this._layerEdited = true;
-    this._layer.fire('pm:edit', { layer: this._layer });
+    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
   },
 });

--- a/src/js/Edit/L.PM.Edit.Marker.js
+++ b/src/js/Edit/L.PM.Edit.Marker.js
@@ -49,7 +49,7 @@ Edit.Marker = Edit.extend({
     }
     this._enabled = true;
 
-    this._layer.fire('pm:enable', { layer: this._layer });
+    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
 
     this.applyOptions();
   },
@@ -66,10 +66,10 @@ Edit.Marker = Edit.extend({
 
     this._layer.off('contextmenu', this._removeMarker, this);
 
-    this._layer.fire('pm:disable', { layer: this._layer });
+    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer });
+      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
   },
@@ -77,14 +77,14 @@ Edit.Marker = Edit.extend({
     const marker = e.target;
     marker.remove();
     // TODO: find out why this is fired manually, shouldn't it be catched by L.PM.Map 'layerremove'?
-    marker.fire('pm:remove', { layer: marker });
-    this._map.fire('pm:remove', { layer: marker });
+    marker.fire('pm:remove', { layer: marker, shape: this.getShape() });
+    this._map.fire('pm:remove', { layer: marker, shape: this.getShape() });
   },
   _onDragEnd(e) {
     const marker = e.target;
 
     // fire the pm:edit event and pass shape and marker
-    marker.fire('pm:edit', { layer: this._layer });
+    marker.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   // overwrite initSnappableMarkers from Snapping.js Mixin

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -80,6 +80,8 @@ Edit.Rectangle = Edit.Polygon.extend({
     this._layer.fire('pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
+      shape: this.getShape(),
+      indexPath: undefined
     });
   },
 
@@ -115,6 +117,8 @@ Edit.Rectangle = Edit.Polygon.extend({
     this._layer.fire('pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
+      shape: this.getShape(),
+      indexPath: undefined
     });
 
     // fire edit event

--- a/src/js/Edit/L.PM.Edit.js
+++ b/src/js/Edit/L.PM.Edit.js
@@ -21,6 +21,9 @@ const Edit = L.Class.extend({
     // if it's a polygon, it means the coordinates array is multi dimensional
     return this._layer instanceof L.Polygon;
   },
+  getShape(){
+    return this._shape;
+  }
 });
 
 export default Edit;

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -211,14 +211,16 @@ const DragMixin = {
   _fireDragStart() {
     this._layer.fire('pm:dragstart', {
       layer: this._layer,
+      shape: this.getShape()
     });
   },
   _fireDrag(e) {
-    this._layer.fire('pm:drag', e);
+    this._layer.fire('pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
     this._layer.fire('pm:dragend', {
       layer: this._layer,
+      shape: this.getShape()
     });
   },
   addDraggingClass() {

--- a/src/js/Mixins/Modes/Mode.Removal.js
+++ b/src/js/Mixins/Modes/Mode.Removal.js
@@ -70,8 +70,14 @@ const GlobalRemovalMode = {
 
     if (removeable) {
       layer.remove();
-      layer.fire('pm:remove', { layer });
-      this.map.fire('pm:remove', { layer });
+      if(layer instanceof L.LayerGroup){
+        layer.fire('pm:remove', { layer, shape: undefined });
+        this.map.fire('pm:remove', { layer, shape: undefined });
+      }else{
+        layer.fire('pm:remove', { layer, shape: layer.pm.getShape() });
+        this.map.fire('pm:remove', { layer, shape: layer.pm.getShape() });
+      }
+
     }
   },
   reinitGlobalRemovalMode({ layer }) {


### PR DESCRIPTION
When a custom shape is created the "default" shape was fired with the events.
Like custom shape "Polygon2" is created, in the  `pm:create` event the `shape` was "Polygon".

This is fixed and also It saves now the shape to a layer, so the custom shape layer can be edited also with the custom shape name.

Additional I added to the most events the shape name.

Fix: #641 