### PR TITLE
Toolbar buttons update

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,15 @@ The following methods are available on `map.pm.Toolbar`:
 | changeControlOrder(`shapes`)                | -         | Change the order of the controls in the Toolbar. You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut` |
 | getControlOrder()                           | `Array`   | Get the current order of the controls.                                                                        |
 
+The following events are available on a map instance:
+
+| Event          | Params | Description                               | Output                                               |
+| :------------- | :----- | :---------------------------------------- | :--------------------------------------------------- |
+| pm:buttonclick | `e`    | Fired when a Toolbar button is clicked    | `btnName`, `button`                                  |
+| pm:actionclick | `e`    | Fired when a Toolbar action is clicked    | `text`, `action`, `btnName`, `button`                |
+
+
+
 ### Feature Requests
 
 I'm adopting the Issue Management of lodash which means, feature requests get the "Feature Request" Label and then get closed.

--- a/README.md
+++ b/README.md
@@ -701,14 +701,15 @@ map.pm.Toolbar.createCustomControl(options)
 
 | Option        | Default     | Description                                                                                      |
 | :------------ | :---------- | :----------------------------------------------------------------------------------------------- |
-| name          | Required    | Name of the control |
-| block         | ''          | block of the control. `draw`, `edit`, `options`⭐, `custom` |
-| title         | ''          | Text showing when you hover the control |
-| className     | ''          | CSS class with the Icon |
-| onClick       | -           | Function fired when clicking the control |
-| afterClick    | -           | Function fired after clicking the control |
-| actions       | [ ]          | Action that appears as tooltip. Look under [actions](#actions) for more information |
-| toggle        | true        | Control can be toggled |
+| name          | Required    | Name of the control                                                                              |
+| block         | ''          | block of the control. `draw`, `edit`, `options`⭐, `custom`                                       |
+| title         | ''          | Text showing when you hover the control                                                          |
+| className     | ''          | CSS class with the Icon                                                                          |
+| onClick       | -           | Function fired when clicking the control                                                         |
+| afterClick    | -           | Function fired after clicking the control                                                        |
+| actions       | [ ]         | Action that appears as tooltip. Look under [actions](#actions) for more information              |
+| toggle        | true        | Control can be toggled                                                                           |
+| disabled      | false       | Control is disabled                                                                              |
 
 
 **Inherit from an Existing Control**
@@ -764,10 +765,11 @@ The following methods are available on `map.pm.Toolbar`:
 | Method                                      | Returns   | Description                                                                                                   |
 | :------------------------------------------ | :-------- | :------------------------------------------------------------------------------------------------------------ |
 | createCustomControl(`options`)              | -         | To add a custom Control to the Toolbar.                                                                       |
-| copyDrawControl(`instance`, `options`)       | `Object`  | Creates a copy of a draw Control. Returns the `drawInstance` and the `control`.                               |
-| changeActionsOfControl(`name`, `actions`)    | -         | Change the actions of an existing button.                                                                     |
+| copyDrawControl(`instance`, `options`)      | `Object`  | Creates a copy of a draw Control. Returns the `drawInstance` and the `control`.                               |
+| changeActionsOfControl(`name`, `actions`)   | -         | Change the actions of an existing button.                                                                     |
 | changeControlOrder(`shapes`)                | -         | Change the order of the controls in the Toolbar. You can pass all shapes and `Edit`, `Drag`, `Removal`, `Cut` |
 | getControlOrder()                           | `Array`   | Get the current order of the controls.                                                                        |
+| setButtonDisabled(`name`, `Boolean`)        | -         | Enable / disable a button.                                                                                    |
 
 The following events are available on a map instance:
 

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -369,4 +369,17 @@ describe('Testing the Toolbar', () => {
       expect(eventFired).to.equal('Cancel');
     });
   });
+  it('Disable button', () => {
+    let eventFired = "";
+    cy.window().then(({map}) => {
+      map.on('pm:buttonclick', ({btnName})=>{eventFired = btnName});
+      map.pm.Toolbar.setButtonDisabled('drawPolygon',true);
+    });
+
+    cy.toolbarButton('polygon').click();
+
+    cy.window().then(() => {
+      expect(eventFired).to.not.equal('drawPolygon');
+    });
+  });
 });

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -350,4 +350,23 @@ describe('Testing the Toolbar', () => {
       });
     });
   });
+  it('Listen on pm:buttonclick and pm:actionclick', () => {
+    let eventFired = "";
+    cy.window().then(({map}) => {
+      map.on('pm:buttonclick', ({btnName})=>{eventFired = btnName});
+      map.on('pm:actionclick', ({text})=>{eventFired = text});
+    });
+
+    cy.toolbarButton('polygon').click();
+
+    cy.window().then(() => {
+      expect(eventFired).to.equal('drawPolygon');
+    });
+
+    cy.get('.button-container.active .action-cancel').click();
+
+    cy.window().then(() => {
+      expect(eventFired).to.equal('Cancel');
+    });
+  });
 });

--- a/demo/customcontrols.js
+++ b/demo/customcontrols.js
@@ -30,3 +30,9 @@ map.pm.Draw.RectangleCopy.setPathOptions({color :'green'});
 map.pm.Toolbar.changeControlOrder(["RectangleCopy"])
 
 
+map.on('pm:actionclick',function (e) {
+    console.log(e)
+})
+map.on('pm:buttonclick',function (e) {
+    console.log(e)
+})

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -144,3 +144,10 @@
   z-index: 801;
 }
 
+.leaflet-buttons-control-button.pm-disabled{
+  background-color: #f4f4f4 !important;
+}
+
+.control-icon.pm-disabled{
+  filter: opacity(0.6);
+}

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -137,6 +137,19 @@ const PMButton = L.Control.extend({
       actionNode.innerHTML = action.text;
 
       if (action.onClick) {
+        const actionClick = ()=>{
+            let btnName = "";
+            const {buttons} = this._map.pm.Toolbar;
+            for(const btn in buttons){
+              if(buttons[btn]._button === button){
+                btnName = btn;
+                break;
+              }
+            }
+            this._map.fire('pm:actionclick', {text: action.text, action, btnName, button});
+        };
+
+        L.DomEvent.addListener(actionNode, 'click', actionClick, this);
         L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
       }
       L.DomEvent.disableClickPropagation(actionNode);
@@ -164,6 +177,15 @@ const PMButton = L.Control.extend({
       if (this._button.disableOtherButtons) {
         this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
       }
+      let btnName = "";
+      const {buttons} = this._map.pm.Toolbar;
+      for(const btn in buttons){
+        if(buttons[btn]._button === button){
+          btnName = btn;
+          break;
+        }
+      }
+      this._map.fire('pm:buttonclick', {btnName, button});
     });
     L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
 

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -136,21 +136,23 @@ const PMButton = L.Control.extend({
 
       actionNode.innerHTML = action.text;
 
-      if (action.onClick) {
-        const actionClick = ()=>{
+      if(!button.disabled) {
+        if (action.onClick) {
+          const actionClick = () => {
             let btnName = "";
             const {buttons} = this._map.pm.Toolbar;
-            for(const btn in buttons){
-              if(buttons[btn]._button === button){
+            for (const btn in buttons) {
+              if (buttons[btn]._button === button) {
                 btnName = btn;
                 break;
               }
             }
             this._map.fire('pm:actionclick', {text: action.text, action, btnName, button});
-        };
+          };
 
-        L.DomEvent.addListener(actionNode, 'click', actionClick, this);
-        L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
+          L.DomEvent.addListener(actionNode, 'click', actionClick, this);
+          L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
+        }
       }
       L.DomEvent.disableClickPropagation(actionNode);
     });
@@ -171,23 +173,30 @@ const PMButton = L.Control.extend({
     if (button.className) {
       L.DomUtil.addClass(image, button.className);
     }
-    // before the actual click, trigger a click on currently toggled buttons to
-    // untoggle them and their functionality
-    L.DomEvent.addListener(newButton, 'click', () => {
-      if (this._button.disableOtherButtons) {
-        this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
-      }
-      let btnName = "";
-      const {buttons} = this._map.pm.Toolbar;
-      for(const btn in buttons){
-        if(buttons[btn]._button === button){
-          btnName = btn;
-          break;
+    if(!button.disabled) {
+      // before the actual click, trigger a click on currently toggled buttons to
+      // untoggle them and their functionality
+      L.DomEvent.addListener(newButton, 'click', () => {
+        if (this._button.disableOtherButtons) {
+          this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
         }
-      }
-      this._map.fire('pm:buttonclick', {btnName, button});
-    });
-    L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
+        let btnName = "";
+        const {buttons} = this._map.pm.Toolbar;
+        for (const btn in buttons) {
+          if (buttons[btn]._button === button) {
+            btnName = btn;
+            break;
+          }
+        }
+        this._map.fire('pm:buttonclick', {btnName, button});
+      });
+      L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
+    }
+
+    if(button.disabled){
+      L.DomUtil.addClass(newButton, 'pm-disabled');
+      L.DomUtil.addClass(image, 'pm-disabled');
+    }
 
     L.DomEvent.disableClickPropagation(newButton);
     return buttonContainer;

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -429,21 +429,7 @@ const Toolbar = L.Class.extend({
       options = { name: options };
     }
 
-    const shapeMapping = {
-      "Marker": "drawMarker",
-      "Circle": "drawCircle",
-      "Polygon": "drawPolygon",
-      "Rectangle": "drawRectangle",
-      "Polyline": "drawPolyline",
-      "Line": "drawPolyline",
-      "CircleMarker": "drawCircleMarker",
-      "Edit": "editMode",
-      "Drag": "dragMode",
-      "Cut": "cutPolygon",
-      "Removal": "removalMode"
-    };
-
-    const instance = shapeMapping[copyInstance] ? shapeMapping[copyInstance] : copyInstance;
+    const instance = this._btnNameMapping(copyInstance);
 
     if (!options.name) {
       throw new TypeError(
@@ -509,6 +495,7 @@ const Toolbar = L.Class.extend({
       cssToggle: options.toggle,
       position: this.options.position,
       actions: options.actions || [],
+      disabled: !!options.disabled,
     };
 
     if (this.options[options.name] !== false) {
@@ -521,19 +508,7 @@ const Toolbar = L.Class.extend({
   },
 
   changeControlOrder(order = []) {
-    const shapeMapping = {
-      "Marker": "drawMarker",
-      "Circle": "drawCircle",
-      "Polygon": "drawPolygon",
-      "Rectangle": "drawRectangle",
-      "Polyline": "drawPolyline",
-      "Line": "drawPolyline",
-      "CircleMarker": "drawCircleMarker",
-      "Edit": "editMode",
-      "Drag": "dragMode",
-      "Cut": "cutPolygon",
-      "Removal": "removalMode"
-    };
+    const shapeMapping = this._shapeMapping();
 
     const _order = [];
     order.forEach((shape) => {
@@ -597,21 +572,7 @@ const Toolbar = L.Class.extend({
     return order;
   },
   changeActionsOfControl(name, actions) {
-    const shapeMapping = {
-      "Marker": "drawMarker",
-      "Circle": "drawCircle",
-      "Polygon": "drawPolygon",
-      "Rectangle": "drawRectangle",
-      "Polyline": "drawPolyline",
-      "Line": "drawPolyline",
-      "CircleMarker": "drawCircleMarker",
-      "Edit": "editMode",
-      "Drag": "dragMode",
-      "Cut": "cutPolygon",
-      "Removal": "removalMode"
-    };
-
-    const btnName = shapeMapping[name] ? shapeMapping[name] : name;
+    const btnName = this._btnNameMapping(name);
 
     if (!btnName) {
       throw new TypeError(
@@ -631,6 +592,30 @@ const Toolbar = L.Class.extend({
     }
     this.buttons[btnName]._button.actions = actions;
     this.changeControlOrder();
+  },
+  setButtonDisabled(name,state){
+    const btnName = this._btnNameMapping(name);
+    this.buttons[btnName]._button.disabled = !!state;
+    this._showHideButtons();
+  },
+  _shapeMapping(){
+    return {
+      "Marker": "drawMarker",
+      "Circle": "drawCircle",
+      "Polygon": "drawPolygon",
+      "Rectangle": "drawRectangle",
+      "Polyline": "drawPolyline",
+      "Line": "drawPolyline",
+      "CircleMarker": "drawCircleMarker",
+      "Edit": "editMode",
+      "Drag": "dragMode",
+      "Cut": "cutPolygon",
+      "Removal": "removalMode"
+    }
+  },
+  _btnNameMapping(name){
+    const shapeMapping = this._shapeMapping();
+    return shapeMapping[name] ? shapeMapping[name] : name;
   }
 });
 


### PR DESCRIPTION
A button can now be disabled `setButtonDisabled(name,state)` Fix: #642 

And the event `pm:buttonclick` is fired when clicking on button. Same for actions `pm:actionclick` Fix: #503 