### PR TITLE
Add toGeoJSON() to getGeomanLayers() and getGeomanDrawLayers()

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ The following methods are available on `map.pm`:
 | setPathOptions(`options`)     | -         | Customize the style of the drawn layer.                                                         |
 | setGlobalOptions(`options`)   | -         | Set drawing options.                                                                            |
 | getGlobalOptions()            | `Object`  | Returns the global options.                                                                     |
-| getGeomanLayers()             | `Array`   | Returns all Geoman layers on the map. Call `.toGeoJSON()` to get the layers as geojson.         |
-| getGeomanDrawLayers()         | `Array`   | Returns all drawn Geoman layers on the map. Call `.toGeoJSON()` to get the layers as geojson.   |
+| getGeomanLayers(`Boolean`)    | `Array`   | Returns all Geoman layers on the map as array. Pass `true` to get a L.FeatureGroup.             |
+| getGeomanDrawLayers(`Boolean`)| `Array`   | Returns all drawn Geoman layers on the map as array. Pass `true` to get a L.FeatureGroup.       |
 
 See the available options in the table below.
 

--- a/README.md
+++ b/README.md
@@ -195,18 +195,18 @@ map.pm.Draw.getShapes();
 
 The following methods are available on `map.pm`:
 
-| Method                        | Returns   | Description                                                              |
-| :---------------------------- | :-------- | :----------------------------------------------------------------------- |
-| enableDraw(`shape`,`options`) | -         | Enable Drawing Mode with the passed shape.                               |
-| disableDraw(`shape`)          | -         | Disable Drawing Mode. The passed shape is optional.                      |
-| Draw.getShapes()              | `Array`   | Array of available shapes.                                               |
-| Draw.getActiveShape()         | `String`  | Returns the active shape.                                                |
-| globalDrawModeEnabled()       | `Boolean` | Returns `true` if global draw mode is enabled. `false` when disabled.    |
-| setPathOptions(`options`)     | -         | Customize the style of the drawn layer.                                  |
-| setGlobalOptions(`options`)   | -         | Set drawing options.                                                     |
-| getGlobalOptions()            | `Object`  | Returns the global options.                                              |
-| getGeomanLayers()             | `Array`   | Returns all Geoman layers on the map.                                    |
-| getGeomanDrawLayers()         | `Array`   | Returns all drawn Geoman layers on the map.                              |
+| Method                        | Returns   | Description                                                                                     |
+| :---------------------------- | :-------- | :---------------------------------------------------------------------------------------------- |
+| enableDraw(`shape`,`options`) | -         | Enable Drawing Mode with the passed shape.                                                      |
+| disableDraw(`shape`)          | -         | Disable Drawing Mode. The passed shape is optional.                                             |
+| Draw.getShapes()              | `Array`   | Array of available shapes.                                                                      |
+| Draw.getActiveShape()         | `String`  | Returns the active shape.                                                                       |
+| globalDrawModeEnabled()       | `Boolean` | Returns `true` if global draw mode is enabled. `false` when disabled.                           |
+| setPathOptions(`options`)     | -         | Customize the style of the drawn layer.                                                         |
+| setGlobalOptions(`options`)   | -         | Set drawing options.                                                                            |
+| getGlobalOptions()            | `Object`  | Returns the global options.                                                                     |
+| getGeomanLayers()             | `Array`   | Returns all Geoman layers on the map. Call `.toGeoJSON()` to get the layers as geojson.         |
+| getGeomanDrawLayers()         | `Array`   | Returns all drawn Geoman layers on the map. Call `.toGeoJSON()` to get the layers as geojson.   |
 
 See the available options in the table below.
 

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -126,27 +126,29 @@ const Map = L.Class.extend({
   disableGlobalCutMode() {
     return this.Draw.Cut.disable();
   },
-  getGeomanLayers(){
+  getGeomanLayers(asGroup = false){
     const layers = findLayers(this.map);
-    layers.toGeoJSON = function(num){ // use function because this have to be the layers array
-      const group = L.featureGroup();
-      this.forEach((layer)=>{
-        group.addLayer(layer);
-      });
-      return group.toGeoJSON(num);
-    };
-    return layers;
+    if(!asGroup) {
+      return layers;
+    }
+    const group = L.featureGroup();
+    group._pmTempLayer = true;
+    layers.forEach((layer) => {
+      group.addLayer(layer);
+    });
+    return group;
   },
-  getGeomanDrawLayers(){
+  getGeomanDrawLayers(asGroup = false){
     const layers = findLayers(this.map).filter(l => l._drawnByGeoman === true);
-    layers.toGeoJSON = function(num){ // use function because this have to be the layers array
-      const group = L.featureGroup();
-      this.forEach((layer)=>{
-        group.addLayer(layer);
-      });
-      return group.toGeoJSON(num);
-    };
-    return layers;
+    if(!asGroup) {
+      return layers;
+    }
+    const group = L.featureGroup();
+    group._pmTempLayer = true;
+    layers.forEach((layer) => {
+      group.addLayer(layer);
+    });
+    return group;
   },
 });
 

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -127,12 +127,27 @@ const Map = L.Class.extend({
     return this.Draw.Cut.disable();
   },
   getGeomanLayers(){
-    return findLayers(this.map);
+    const layers = findLayers(this.map);
+    layers.toGeoJSON = function(num){ // use function because this have to be the layers array
+      const group = L.featureGroup();
+      this.forEach((layer)=>{
+        group.addLayer(layer);
+      });
+      return group.toGeoJSON(num);
+    };
+    return layers;
   },
   getGeomanDrawLayers(){
-    return findLayers(this.map).filter(l => l._drawnByGeoman === true);
-  }
-
+    const layers = findLayers(this.map).filter(l => l._drawnByGeoman === true);
+    layers.toGeoJSON = function(num){ // use function because this have to be the layers array
+      const group = L.featureGroup();
+      this.forEach((layer)=>{
+        group.addLayer(layer);
+      });
+      return group.toGeoJSON(num);
+    };
+    return layers;
+  },
 });
 
 export default Map;


### PR DESCRIPTION
Add `toGeoJSON()` to `getGeomanLayers()` and `getGeomanDrawLayers()`

Example:
```
map.pm.getGeomanLayers().toGeoJSON()
```

I add the function `toGeoJSON()` to the layers result array, so that it is possible to call a function "after" a function. Are there problems when we do this? 