### PR TITLE
Throttle snapping fix

### DIFF
--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -92,7 +92,6 @@ Edit.Line = Edit.extend({
     // remove onRemove listener
     this._layer.off('remove', this._onLayerRemove, this);
 
-
     if (!this.options.allowSelfIntersection) {
       this._layer.off(
         'pm:vertexremoved',

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -28,10 +28,14 @@ Edit.Rectangle = Edit.Polygon.extend({
 
     // convenience alias, for better readability
     [this._cornerMarkers] = this._markers;
-
+  },
+  applyOptions() {
     if (this.options.snappable) {
       this._initSnappableMarkers();
+    } else {
+      this._disableSnapping();
     }
+    this._addMarkerEvents();
   },
 
   // creates initial markers for coordinates
@@ -45,18 +49,22 @@ Edit.Rectangle = Edit.Polygon.extend({
     marker._index = index;
     marker._pmTempLayer = true;
 
-    marker.on('dragstart', this._onMarkerDragStart, this);
-    marker.on('drag', this._onMarkerDrag, this);
-    marker.on('dragend', this._onMarkerDragEnd, this);
-    marker.on('pm:snap', this._adjustRectangleForMarkerSnap, this);
-    if (!this.options.preventMarkerRemoval) {
-      marker.on('contextmenu', this._removeMarker, this);
-    }
     this._markerGroup.addLayer(marker);
 
     return marker;
   },
-
+  // Add marker events after adding the snapping events to the markers, beacause of the execution order
+  _addMarkerEvents(){
+    this._markers[0].forEach((marker)=>{
+      marker.on('dragstart', this._onMarkerDragStart, this);
+      marker.on('drag', this._onMarkerDrag, this);
+      marker.on('dragend', this._onMarkerDragEnd, this);
+      marker.on('pm:snap', this._adjustRectangleForMarkerSnap, this);
+      if (!this.options.preventMarkerRemoval) {
+        marker.on('contextmenu', this._removeMarker, this);
+      }
+    });
+  },
   // Empty callback for 'contextmenu' binding set in L.PM.Edit.Line.js's _createMarker method (AKA, right-click on marker event)
   // (A Rectangle is designed to always remain a "true" rectangle -- if you want it editable, use Polygon Tool instead!!!)
   _removeMarker() {

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -45,7 +45,7 @@ const GlobalEditMode = {
     });
 
     // cleanup layer off event
-    this.map.off('layeroff', this.throttledReInitEdit, this);
+    this.map.off('layeradd', this.throttledReInitEdit, this);
 
     // Set toolbar button to currect status
     this.Toolbar.toggleButton('editMode', status);

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -36,6 +36,11 @@ const SnapMixin = {
     // meanwhile, new layers could've been added to the map
     delete this._snapList;
 
+    if(this.throttledList) {
+      this._map.off('layeradd', this.throttledList, this);
+      this.throttledList = undefined;
+    }
+
     // remove map event
     this._map.off('pm:remove', this._handleSnapLayerRemoval, this);
 
@@ -46,8 +51,9 @@ const SnapMixin = {
     }
   },
   _handleSnapping(e) {
-    function throttledList() {
-      return L.Util.throttle(this._createSnapList, 100, this);
+
+    if(!this.throttledList) {
+      this.throttledList =  L.Util.throttle(this._createSnapList, 100, this);
     }
 
     // if snapping is disabled via holding ALT during drag, stop right here
@@ -62,8 +68,8 @@ const SnapMixin = {
       this._createSnapList();
 
       // re-create the snaplist again when a layer is added during draw
-      this._map.off('layeradd', throttledList, this);
-      this._map.on('layeradd', throttledList, this);
+      this._map.off('layeradd', this.throttledList, this);
+      this._map.on('layeradd', this.throttledList, this);
     }
 
     // if there are no layers to snap to, stop here


### PR DESCRIPTION
A Bugfix if a layer is added while drawing mode, it can now snapped

Also fixed a small snapping bug on rectangles (wrong order of execution of the listeners)