### PR TITLE
Edit.LayerGroup Refactoring 

### DIFF
--- a/cypress/fixtures/FeatureCollectionEventFire.json
+++ b/cypress/fixtures/FeatureCollectionEventFire.json
@@ -1,0 +1,29 @@
+{
+    "type":"FeatureCollection",
+    "features":[
+        {
+            "type":"Feature",
+            "geometry":{
+                "type":"MultiPoint",
+                "coordinates":[
+                    [
+                        32.83604819,
+                        40.0169319
+                    ]
+                ]
+            }
+        },
+        {
+            "type":"Feature",
+            "geometry":{
+                "type":"MultiPoint",
+                "coordinates":[
+                    [
+                        32.8298979,
+                        40.02567418
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -172,6 +172,19 @@ Cypress.Commands.add('drawShape', (shape, ignore) => {
         });
     }
 
+    if (shape === 'FeatureCollectionEventFire') {
+      cy.fixture(shape)
+        .then(json => {
+          //
+          const layer = L.geoJSON(json).addTo(map);
+          const bounds = layer.getBounds();
+          map.fitBounds(bounds);
+
+          return layer;
+        })
+        .as('feature');
+    }
+
     if (shape === 'FeatureCollectionWithCircles') {
       cy.fixture(shape, ignore)
         .then(json => {

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -1,6 +1,7 @@
 import Draw from './L.PM.Draw';
 
 import { getTranslation } from '../helpers';
+import Utils from "../L.PM.Utils";
 
 Draw.Circle = Draw.extend({
   initialize(map) {
@@ -84,7 +85,7 @@ Draw.Circle = Draw.extend({
     this._otherSnapLayers = [];
 
     // fire drawstart event
-    this._map.fire('pm:drawstart', {
+    Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -121,7 +122,7 @@ Draw.Circle = Draw.extend({
     }
 
     // fire drawend event
-    this._map.fire('pm:drawend', { shape: this._shape });
+    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   enabled() {
@@ -190,7 +191,7 @@ Draw.Circle = Draw.extend({
         getTranslation('tooltips.finishCircle')
       );
 
-      this._layer.fire('pm:centerplaced', {
+      Utils._fireEvent(this._layer,'pm:centerplaced', {
         workingLayer: this._layer,
         latlng,
         shape: this._shape
@@ -224,7 +225,7 @@ Draw.Circle = Draw.extend({
     this.disable();
 
     // fire the pm:create event and pass shape and layer
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: circleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -1,6 +1,7 @@
 import Draw from './L.PM.Draw';
 
 import { getTranslation } from '../helpers';
+import Utils from "../L.PM.Utils";
 
 Draw.CircleMarker = Draw.Marker.extend({
   initialize(map) {
@@ -112,7 +113,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire drawstart event
-    this._map.fire('pm:drawstart', {
+    Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -164,7 +165,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire drawend event
-    this._map.fire('pm:drawend', { shape: this._shape });
+    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   _placeCenterMarker(e) {
@@ -198,7 +199,7 @@ Draw.CircleMarker = Draw.Marker.extend({
         getTranslation('tooltips.finishCircle')
       );
 
-      this._layer.fire('pm:centerplaced', {
+      Utils._fireEvent(this._layer,'pm:centerplaced', {
         shape: this._shape,
         workingLayer: this._layer,
         latlng,
@@ -260,7 +261,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire the pm:create event and pass shape and marker
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       marker, // DEPRECATED
       layer: marker,
@@ -294,7 +295,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     this.disable();
 
     // fire the pm:create event and pass shape and layer
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: circleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -1,5 +1,6 @@
 import Draw from './L.PM.Draw';
 import {difference, intersect} from "../helpers/turfHelper";
+import Utils from "../L.PM.Utils";
 
 Draw.Cut = Draw.Polygon.extend({
   initialize(map) {
@@ -35,21 +36,21 @@ Draw.Cut = Draw.Polygon.extend({
 
     this._editedLayers.forEach(({layer, originalLayer}) =>{
       // fire pm:cut on the cutted layer
-      originalLayer.fire('pm:cut', {
+      Utils._fireEvent(originalLayer,'pm:cut', {
         shape: this._shape,
         layer,
         originalLayer,
       });
 
       // fire pm:cut on the map
-      this._map.fire('pm:cut', {
+      Utils._fireEvent(this._map,'pm:cut', {
         shape: this._shape,
         layer,
         originalLayer,
       });
 
       // fire edit event after cut
-      originalLayer.fire('pm:edit', { layer: originalLayer, shape: originalLayer.pm.getShape()});
+      Utils._fireEvent(originalLayer,'pm:edit', { layer: originalLayer, shape: originalLayer.pm.getShape()});
     });
     this._editedLayers = [];
   },

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -5,7 +5,6 @@ import get from "lodash/get";
 import Utils from "../L.PM.Utils";
 import Draw from './L.PM.Draw';
 import {difference, intersect} from "../helpers/turfHelper";
-import Utils from "../L.PM.Utils";
 
 Draw.Cut = Draw.Polygon.extend({
   initialize(map) {

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -1,5 +1,6 @@
 import kinks from '@turf/kinks';
 import Draw from './L.PM.Draw';
+import Utils from "../L.PM.Utils";
 
 import { getTranslation } from '../helpers';
 
@@ -98,7 +99,7 @@ Draw.Line = Draw.extend({
 
 
     // fire drawstart event
-    this._map.fire('pm:drawstart', {
+    Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -140,7 +141,7 @@ Draw.Line = Draw.extend({
     }
 
     // fire drawend event
-    this._map.fire('pm:drawend', { shape: this._shape });
+    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
 
   },
@@ -259,7 +260,7 @@ Draw.Line = Draw.extend({
 
     this._hintline.setLatLngs([latlng, latlng]);
 
-    this._layer.fire('pm:vertexadded', {
+    Utils._fireEvent(this._layer,'pm:vertexadded', {
       shape: this._shape,
       workingLayer: this._layer,
       marker: newMarker,
@@ -322,7 +323,7 @@ Draw.Line = Draw.extend({
     this.disable();
 
     // fire the pm:create event and pass shape and layer
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: polylineLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -1,6 +1,6 @@
 import Draw from './L.PM.Draw';
-
 import { getTranslation } from '../helpers';
+import Utils from "../L.PM.Utils";
 
 Draw.Marker = Draw.extend({
   initialize(map) {
@@ -55,7 +55,7 @@ Draw.Marker = Draw.extend({
     });
 
     // fire drawstart event
-    this._map.fire('pm:drawstart', {
+    Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -96,7 +96,7 @@ Draw.Marker = Draw.extend({
     }
 
     // fire drawend event
-    this._map.fire('pm:drawend', { shape: this._shape });
+    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   enabled() {
@@ -154,7 +154,7 @@ Draw.Marker = Draw.extend({
     }
 
     // fire the pm:create event and pass shape and marker
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       marker, // DEPRECATED
       layer: marker,

--- a/src/js/Draw/L.PM.Draw.Polygon.js
+++ b/src/js/Draw/L.PM.Draw.Polygon.js
@@ -1,4 +1,5 @@
 import Draw from './L.PM.Draw';
+import Utils from "../L.PM.Utils";
 
 import { getTranslation } from '../helpers';
 
@@ -81,7 +82,7 @@ Draw.Polygon = Draw.Line.extend({
     this.disable();
 
     // fire the pm:create event and pass shape and layer
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: polygonLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -1,4 +1,5 @@
 import Draw from './L.PM.Draw';
+import Utils from "../L.PM.Utils";
 
 import { getTranslation } from '../helpers';
 
@@ -94,7 +95,7 @@ Draw.Rectangle = Draw.extend({
     this._otherSnapLayers = [];
 
     // fire drawstart event
-    this._map.fire('pm:drawstart', {
+    Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -130,7 +131,7 @@ Draw.Rectangle = Draw.extend({
       this._cleanupSnapping();
     }
     // fire drawend event
-    this._map.fire('pm:drawend', { shape: this._shape });
+    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
 
   },
@@ -259,7 +260,7 @@ Draw.Rectangle = Draw.extend({
     this.disable();
 
     // fire the pm:create event and pass shape and layer
-    this._map.fire('pm:create', {
+    Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: rectangleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -1,4 +1,5 @@
 import SnapMixin from '../Mixins/Snapping';
+import Utils from "../L.PM.Utils";
 
 const Draw = L.Class.extend({
   includes: [SnapMixin],
@@ -83,12 +84,12 @@ const Draw = L.Class.extend({
   _setGlobalDrawMode() {
     // extended to all PM.Draw shapes
     if (this._shape === "Cut") {
-      this._map.fire('pm:globalcutmodetoggled', {
+      Utils._fireEvent(this._map,'pm:globalcutmodetoggled', {
         enabled: !!this._enabled,
         map: this._map,
       });
     } else {
-      this._map.fire('pm:globaldrawmodetoggled', {
+      Utils._fireEvent(this._map,'pm:globaldrawmodetoggled', {
         enabled: this._enabled,
         shape: this._shape,
         map: this._map,

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -35,7 +35,7 @@ Edit.Circle = Edit.extend({
     // create polygon around the circle border
     this._updateHiddenPolyCircle();
 
-    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // if it's not enabled, it doesn't need to be disabled
@@ -64,11 +64,11 @@ Edit.Circle = Edit.extend({
 
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
+      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
 
-    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     return true;
   },
   enabled() {
@@ -178,7 +178,7 @@ Edit.Circle = Edit.extend({
 
     this._updateHiddenPolyCircle();
 
-    this._layer.fire('pm:centerplaced', {
+    Utils._fireEvent(this._layer,'pm:centerplaced', {
       layer: this._layer,
       latlng: center,
       shape: this.getShape()
@@ -211,7 +211,7 @@ Edit.Circle = Edit.extend({
     this._layer.off('pm:dragstart', this._unsnap, this);
   },
   _onMarkerDragStart(e) {
-    this._layer.fire('pm:markerdragstart', {
+    Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -219,7 +219,7 @@ Edit.Circle = Edit.extend({
     });
   },
   _onMarkerDrag(e) {
-    this._layer.fire('pm:markerdrag', {
+    Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -231,7 +231,7 @@ Edit.Circle = Edit.extend({
     this._fireEdit();
 
     // fire markerdragend event
-    this._layer.fire('pm:markerdragend', {
+    Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -240,17 +240,17 @@ Edit.Circle = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   _fireDragStart() {
-    this._layer.fire('pm:dragstart', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:dragstart', { layer: this._layer, shape: this.getShape() });
   },
   _fireDrag(e) {
-    this._layer.fire('pm:drag', Object.assign({},e, {shape:this.getShape()}));
+    Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
-    this._layer.fire('pm:dragend', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:dragend', { layer: this._layer, shape: this.getShape() });
   },
   _updateHiddenPolyCircle() {
     if (this._hiddenPolyCircle) {

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -34,7 +34,7 @@ Edit.CircleMarker = Edit.extend({
     // create polygon around the circle border
     this._updateHiddenPolyCircle();
 
-    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // prevent disabling if layer is being dragged
@@ -64,10 +64,10 @@ Edit.CircleMarker = Edit.extend({
     // only fire events if it was enabled before
     if (!this.enabled()) {
       if (this._layerEdited) {
-        this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
+        Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
       }
       this._layerEdited = false;
-      this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
+      Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     }
 
     layer.pm._enabled = false;
@@ -201,7 +201,7 @@ Edit.CircleMarker = Edit.extend({
     this._outerMarker.setLatLng(outer);
     this._syncHintLine();
 
-    this._layer.fire('pm:centerplaced', {
+    Utils._fireEvent(this._layer,'pm:centerplaced', {
       layer: this._layer,
       latlng: center,
       shape: this.getShape()
@@ -241,11 +241,11 @@ Edit.CircleMarker = Edit.extend({
       this.disable();
     }
     this._layer.remove();
-    this._layer.fire('pm:remove', { layer: this._layer, shape: this.getShape() });
-    this._map.fire('pm:remove', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:remove', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._map,'pm:remove', { layer: this._layer, shape: this.getShape() });
   },
   _onMarkerDragStart(e) {
-    this._layer.fire('pm:markerdragstart', {
+    Utils._fireEvent(this._layer,'pm:markerdragstart', {
       markerEvent: e,
       layer: this._layer,
       shape: this.getShape(),
@@ -253,7 +253,7 @@ Edit.CircleMarker = Edit.extend({
     });
   },
   _onMarkerDrag(e) {
-    this._layer.fire('pm:markerdrag', {
+    Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -261,7 +261,7 @@ Edit.CircleMarker = Edit.extend({
     });
   },
   _onMarkerDragEnd(e) {
-    this._layer.fire('pm:markerdragend', {
+    Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -270,7 +270,7 @@ Edit.CircleMarker = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   // _initSnappableMarkers when option editable is not true

--- a/src/js/Edit/L.PM.Edit.ImageOverlay.js
+++ b/src/js/Edit/L.PM.Edit.ImageOverlay.js
@@ -1,4 +1,5 @@
 import Edit from './L.PM.Edit';
+import Utils from "../L.PM.Utils";
 
 Edit.ImageOverlay = Edit.extend({
   _shape: 'ImageOverlay',
@@ -37,7 +38,7 @@ Edit.ImageOverlay = Edit.extend({
     // create markers for four corners of ImageOverlay
     this._otherSnapLayers = L.PM.Edit.Rectangle.prototype._findCorners.apply(this);
 
-    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // prevent disabling if layer is being dragged
@@ -55,10 +56,10 @@ Edit.ImageOverlay = Edit.extend({
     // only fire events if it was enabled before
     if (!this.enabled()) {
       if (this._layerEdited) {
-        layer.fire('pm:update', { layer, shape: this.getShape() });
+        Utils._fireEvent(layer,'pm:update', { layer, shape: this.getShape() });
       }
       this._layerEdited = false;
-      layer.fire('pm:disable', { layer, shape: this.getShape() });
+      Utils._fireEvent(layer,'pm:disable', { layer, shape: this.getShape() });
     }
 
     this._layer.off('contextmenu', this._removeMarker, this);
@@ -67,7 +68,7 @@ Edit.ImageOverlay = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
 });

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -69,7 +69,7 @@ Edit.Line = Edit.extend({
     }else{
       this.cachedColor = undefined;
     }
-    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(poly = this._layer) {
     // if it's not enabled, it doesn't need to be disabled
@@ -111,10 +111,10 @@ Edit.Line = Edit.extend({
     }
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
+      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
-    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     return true;
   },
   enabled() {
@@ -298,7 +298,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
 
-    this._layer.fire('pm:vertexadded', {
+    Utils._fireEvent(this._layer,'pm:vertexadded', {
       layer: this._layer,
       marker: newM,
       indexPath: this.findDeepMarkerIndex(this._markers, newM).indexPath,
@@ -358,7 +358,7 @@ Edit.Line = Edit.extend({
       }
 
       // fire intersect event
-      this._layer.fire('pm:intersect', {
+      Utils._fireEvent(this._layer,'pm:intersect', {
         layer: this._layer,
         intersection: kinks(this._layer.toGeoJSON(15)),
         shape: this.getShape()
@@ -501,7 +501,7 @@ Edit.Line = Edit.extend({
     this._fireEdit();
 
     // fire vertex removal event
-    this._layer.fire('pm:vertexremoved', {
+    Utils._fireEvent(this._layer,'pm:vertexremoved', {
       layer: this._layer,
       marker,
       indexPath,
@@ -605,7 +605,7 @@ Edit.Line = Edit.extend({
     const marker = e.target;
     const { indexPath } = this.findDeepMarkerIndex(this._markers, marker);
 
-    this._layer.fire('pm:markerdragstart', {
+    Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       indexPath,
@@ -693,7 +693,7 @@ Edit.Line = Edit.extend({
     if (!this.options.allowSelfIntersection) {
       this._handleLayerStyle();
     }
-    this._layer.fire('pm:markerdrag', {
+    Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -704,7 +704,7 @@ Edit.Line = Edit.extend({
     const marker = e.target;
     const { indexPath } = this.findDeepMarkerIndex(this._markers, marker);
 
-    this._layer.fire('pm:markerdragend', {
+    Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       indexPath,
@@ -739,6 +739,6 @@ Edit.Line = Edit.extend({
   _fireEdit() {
     // fire edit event
     this._layerEdited = true;
-    this._layer.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
   },
 });

--- a/src/js/Edit/L.PM.Edit.Marker.js
+++ b/src/js/Edit/L.PM.Edit.Marker.js
@@ -1,4 +1,5 @@
 import Edit from './L.PM.Edit';
+import Utils from "../L.PM.Utils";
 
 Edit.Marker = Edit.extend({
   _shape: 'Marker',
@@ -19,9 +20,10 @@ Edit.Marker = Edit.extend({
       return;
     }
     this._enabled = true;
-
     this.applyOptions();
-    this._layer.fire('pm:enable', { layer: this._layer, shape: this.getShape() });
+
+  //  Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable() {
     this._enabled = false;
@@ -31,10 +33,10 @@ Edit.Marker = Edit.extend({
 
     this._layer.off('contextmenu', this._removeMarker, this);
 
-    this._layer.fire('pm:disable', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
 
     if (this._layerEdited) {
-      this._layer.fire('pm:update', { layer: this._layer, shape: this.getShape() });
+      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
   },
@@ -48,7 +50,7 @@ Edit.Marker = Edit.extend({
       this.disable();
     }
   },
-  lapplyOptions() {
+  applyOptions() {
     if (this.options.snappable) {
       this._initSnappableMarkers();
     } else {
@@ -69,14 +71,14 @@ Edit.Marker = Edit.extend({
     const marker = e.target;
     marker.remove();
     // TODO: find out why this is fired manually, shouldn't it be catched by L.PM.Map 'layerremove'?
-    marker.fire('pm:remove', { layer: marker, shape: this.getShape() });
-    this._map.fire('pm:remove', { layer: marker, shape: this.getShape() });
+    Utils._fireEvent(marker,'pm:remove', { layer: marker, shape: this.getShape() });
+    Utils._fireEvent(this._map,'pm:remove', { layer: marker, shape: this.getShape() });
   },
   _onDragEnd(e) {
     const marker = e.target;
 
     // fire the pm:edit event and pass shape and marker
-    marker.fire('pm:edit', { layer: this._layer, shape: this.getShape() });
+    Utils._fireEvent(marker,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   // overwrite initSnappableMarkers from Snapping.js Mixin

--- a/src/js/Edit/L.PM.Edit.Marker.js
+++ b/src/js/Edit/L.PM.Edit.Marker.js
@@ -48,7 +48,7 @@ Edit.Marker = Edit.extend({
       this.disable();
     }
   },
-  applyOptions() {
+  lapplyOptions() {
     if (this.options.snappable) {
       this._initSnappableMarkers();
     } else {

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -2,6 +2,7 @@
 // https://github.com/Leaflet/Leaflet.draw/blob/master/src/edit/handler/Edit.Rectangle.js
 
 import Edit from './L.PM.Edit';
+import Utils from "../L.PM.Utils";
 
 Edit.Rectangle = Edit.Polygon.extend({
   _shape: 'Rectangle',
@@ -77,7 +78,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // (Without this, it's occasionally possible for a marker to get stuck as 'snapped,' which prevents Rectangle resizing)
     draggedMarker._snapped = false;
 
-    this._layer.fire('pm:markerdragstart', {
+    Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -99,7 +100,7 @@ Edit.Rectangle = Edit.Polygon.extend({
       this._adjustRectangleForMarkerMove(draggedMarker);
     }
 
-    this._layer.fire('pm:markerdrag', {
+    Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -121,7 +122,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // Update bounding box
     this._layer.setLatLngs(corners);
 
-    this._layer.fire('pm:markerdragend', {
+    Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),

--- a/src/js/Edit/L.PM.Edit.js
+++ b/src/js/Edit/L.PM.Edit.js
@@ -24,24 +24,6 @@ const Edit = L.Class.extend({
   getShape(){
     return this._shape;
   },
-  // check if the popup is open
-  _isPopupOpen(){
-    const layerpopup = this._layer.isPopupOpen();
-    if(layerpopup){
-      return true;
-    }
-
-    if(this._layerGroup && Object.keys(this._layerGroup).length > 0){
-      for (const id in this._layerGroup){
-        if(this._layerGroup[id].isPopupOpen()){
-          return true;
-        }
-      }
-    }
-
-    return false;
-
-  }
 });
 
 export default Edit;

--- a/src/js/Edit/L.PM.Edit.js
+++ b/src/js/Edit/L.PM.Edit.js
@@ -23,6 +23,24 @@ const Edit = L.Class.extend({
   },
   getShape(){
     return this._shape;
+  },
+  // check if the popup is open
+  _isPopupOpen(){
+    const layerpopup = this._layer.isPopupOpen();
+    if(layerpopup){
+      return true;
+    }
+
+    if(this._layerGroup && Object.keys(this._layerGroup).length > 0){
+      for (const id in this._layerGroup){
+        if(this._layerGroup[id].isPopupOpen()){
+          return true;
+        }
+      }
+    }
+
+    return false;
+
   }
 });
 

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -30,7 +30,7 @@ const Map = L.Class.extend({
 
     L.PM.activeLang = lang;
     this.map.pm.Toolbar.reinit();
-    this.map.fire("pm:langchange", {
+    Utils._fireEvent(this.map,"pm:langchange", {
       oldLang,
       activeLang: lang,
       fallback,

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -1,3 +1,5 @@
+import Utils from "../L.PM.Utils";
+
 const DragMixin = {
   enableLayerDrag() {
     // before enabling layer drag, disable layer editing
@@ -88,7 +90,6 @@ const DragMixin = {
 
     // save for delta calculation
     this._tempDragCoord = e.latlng;
-
 
     this._layer._map.on('mouseup', this._dragMixinOnMouseUp, this);
 
@@ -213,16 +214,16 @@ const DragMixin = {
     this._fireDrag(e);
   },
   _fireDragStart() {
-    this._layer.fire('pm:dragstart', {
+    Utils._fireEvent(this._layer,'pm:dragstart', {
       layer: this._layer,
       shape: this.getShape()
     });
   },
   _fireDrag(e) {
-    this._layer.fire('pm:drag', Object.assign({},e, {shape:this.getShape()}));
+    Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
-    this._layer.fire('pm:dragend', {
+    Utils._fireEvent(this._layer,'pm:dragend', {
       layer: this._layer,
       shape: this.getShape()
     });

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -89,6 +89,7 @@ const DragMixin = {
     // save for delta calculation
     this._tempDragCoord = e.latlng;
 
+
     this._layer._map.on('mouseup', this._dragMixinOnMouseUp, this);
 
     // listen to mousemove on map (instead of polygon),

--- a/src/js/Mixins/Modes/Mode.Drag.js
+++ b/src/js/Mixins/Modes/Mode.Drag.js
@@ -65,7 +65,7 @@ const GlobalDragMode = {
     }
   },
   _fireDragModeEvent(enabled) {
-    this.map.fire('pm:globaldragmodetoggled', {
+    Utils._fireEvent(this.map,'pm:globaldragmodetoggled', {
       enabled,
       map: this.map,
     });

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -9,7 +9,7 @@ const GlobalEditMode = {
     const options = {
       snappable: this._globalSnappingEnabled,
       ...o
-    }
+    };
 
     const status = true;
 
@@ -45,7 +45,7 @@ const GlobalEditMode = {
     });
 
     // cleanup layer off event
-    this.map.off('layeroff', this.throttledReInitEdit, this);
+    this.map.off('layeradd', this.throttledReInitEdit, this);
 
     // Set toolbar button to currect status
     this.Toolbar.toggleButton('editMode', status);
@@ -75,22 +75,22 @@ const GlobalEditMode = {
     }
   },
   handleLayerAdditionInGlobalEditMode({ layer }) {
-    // when global edit mode is enabled and a layer is added to the map,
-    // enable edit for that layer if it's relevant
+      // when global edit mode is enabled and a layer is added to the map,
+      // enable edit for that layer if it's relevant
 
-    // do nothing if layer is not handled by leaflet so it doesn't fire unnecessarily
-    const isRelevant = !!layer.pm && !layer._pmTempLayer;
-    if (!isRelevant) {
-      return;
-    }
+      // do nothing if layer is not handled by leaflet so it doesn't fire unnecessarily
+      const isRelevant = !!layer.pm && !layer._pmTempLayer;
+      if (!isRelevant) {
+        return;
+      }
 
-    if (this.globalEditModeEnabled()) {
+      if (this.globalEditModeEnabled()) {
       // TODO: this._globalSnappingEnabled is a Pro Feature. Remove this option from OSS?
       layer.pm.enable({ ...this.globalOptions, snappable: this._globalSnappingEnabled });
-    }
+      }
   },
   _fireEditModeEvent(enabled) {
-    this.map.fire('pm:globaleditmodetoggled', {
+    Utils._fireEvent(this.map,'pm:globaleditmodetoggled', {
       enabled,
       map: this.map,
     });

--- a/src/js/Mixins/Modes/Mode.Removal.js
+++ b/src/js/Mixins/Modes/Mode.Removal.js
@@ -1,3 +1,5 @@
+import Utils from "../../L.PM.Utils";
+
 const GlobalRemovalMode = {
   enableGlobalRemovalMode() {
     const isRelevant = layer =>
@@ -68,7 +70,7 @@ const GlobalRemovalMode = {
     }
   },
   _fireRemovalModeEvent(enabled) {
-    this.map.fire('pm:globalremovalmodetoggled', {
+    Utils._fireEvent(this.map,'pm:globalremovalmodetoggled', {
       enabled,
       map: this.map,
     });
@@ -83,11 +85,11 @@ const GlobalRemovalMode = {
     if (removeable) {
       layer.remove();
       if(layer instanceof L.LayerGroup){
-        layer.fire('pm:remove', { layer, shape: undefined });
-        this.map.fire('pm:remove', { layer, shape: undefined });
+        Utils._fireEvent(layer,'pm:remove', { layer, shape: undefined });
+        Utils._fireEvent(this.map,'pm:remove', { layer, shape: undefined });
       }else{
-        layer.fire('pm:remove', { layer, shape: layer.pm.getShape() });
-        this.map.fire('pm:remove', { layer, shape: layer.pm.getShape() });
+        Utils._fireEvent(layer,'pm:remove', { layer, shape: layer.pm.getShape() });
+        Utils._fireEvent(this.map,'pm:remove', { layer, shape: layer.pm.getShape() });
       }
 
     }

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -111,8 +111,8 @@ const SnapMixin = {
       distance: closestLayer.distance,
     };
 
-    eventInfo.marker.fire('pm:snapdrag', eventInfo);
-    this._layer.fire('pm:snapdrag', eventInfo);
+    Utils._fireEvent(eventInfo.marker,'pm:snapdrag', eventInfo);
+    Utils._fireEvent(this._layer,'pm:snapdrag', eventInfo);
 
     if (closestLayer.distance < minDistance) {
       // snap the marker
@@ -122,8 +122,8 @@ const SnapMixin = {
 
       const triggerSnap = () => {
         this._snapLatLng = snapLatLng;
-        marker.fire('pm:snap', eventInfo);
-        this._layer.fire('pm:snap', eventInfo);
+        Utils._fireEvent(marker,'pm:snap', eventInfo);
+        Utils._fireEvent(this._layer,'pm:snap', eventInfo);
       };
 
       // check if the snapping position differs from the last snap
@@ -144,8 +144,8 @@ const SnapMixin = {
       marker._snapped = false;
 
       // and fire unsnap event
-      eventInfo.marker.fire('pm:unsnap', eventInfo);
-      this._layer.fire('pm:unsnap', eventInfo);
+      Utils._fireEvent(eventInfo.marker,'pm:unsnap', eventInfo);
+      Utils._fireEvent(this._layer,'pm:unsnap', eventInfo);
     }
 
     return true;

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -1,4 +1,5 @@
 import { getTranslation } from '../helpers';
+import Utils from "../L.PM.Utils";
 
 const PMButton = L.Control.extend({
   options: {
@@ -147,7 +148,7 @@ const PMButton = L.Control.extend({
                 break;
               }
             }
-            this._map.fire('pm:actionclick', {text: action.text, action, btnName, button});
+            Utils._fireEvent(this._map,'pm:actionclick', {text: action.text, action, btnName, button});
           };
 
           L.DomEvent.addListener(actionNode, 'click', actionClick, this);
@@ -188,7 +189,7 @@ const PMButton = L.Control.extend({
             break;
           }
         }
-        this._map.fire('pm:buttonclick', {btnName, button});
+        Utils._fireEvent(this._map,'pm:buttonclick', {btnName, button});
       });
       L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
     }


### PR DESCRIPTION
 Edit.LayerGroup refactoring -> events now called directly to FeatureGroups over the `fire` function instead of adding a listener to the childs. 

The leaflet `fire` function is replaced by `L.PM.Utils._fireEvent`

Fixes: #549