### PR TITLE
Support direction RTL

### DIFF
--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -100,6 +100,7 @@
   left: 100%;
   display: none;
   white-space: nowrap;
+  direction: ltr;
 }
 
 .leaflet-right


### PR DESCRIPTION
Set the action-container always to direction ltr, so the css displayed correct (corners etc.)

We can do this, because we center the action-text and so it does not matter if it is displayed ltr or rtl.

Old:
![rtl_missplaced_buttons](https://user-images.githubusercontent.com/19800037/97775769-8f034300-1b63-11eb-9f32-b2476c9bd137.PNG)

New:
![rtl_buttons](https://user-images.githubusercontent.com/19800037/97775771-8f9bd980-1b63-11eb-8511-1b0d277cf95e.PNG)


The only problem that will be exist longer, is the tooltip rtl support, but this is a Leaflet Core Bug https://github.com/Leaflet/Leaflet/issues/7201
![rtl_tooltip](https://user-images.githubusercontent.com/19800037/97775823-f7522480-1b63-11eb-9b90-1f291e94a9a4.PNG)

But this can be fixed if following is added to the css:

```
.leaflet-tooltip-pane > * {
    direction: rtl;
}
.leaflet-tooltip-pane {
    direction: ltr;
}
```
![rtl_tooltip_working](https://user-images.githubusercontent.com/19800037/97775848-2bc5e080-1b64-11eb-8c9c-0d0265859f32.PNG)


Fix: #618