### PR TITLE
Add Persian translation (RTL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Change the language of user-facing copy in leaflet-geoman
 map.pm.setLang('de');
 ```
 
-Currently available languages are `en`, `de`, `it`, `ru`, `ro`, `es`, `fr`, `pt_br`, `id`, `zh`, `zh_tw`, `nl`, `el`, `pl`, `sv`, `da`, `hu` and `no`.
+Currently available languages are `en`, `de`, `fa`, `it`, `ru`, `ro`, `es`, `fr`, `pt_br`, `id`, `zh`, `zh_tw`, `nl`, `el`, `pl`, `sv`, `da`, `hu` and `no`.
 To add translations to the plugin, you can add [a translation file](src/assets/translations) via Pull Request.
 
 You can also provide your own custom translations.

--- a/src/assets/translations/fa.json
+++ b/src/assets/translations/fa.json
@@ -1,0 +1,32 @@
+{
+  "tooltips": {
+    "placeMarker": "کلیک برای جانمایی نشان",
+    "firstVertex": "کلیک برای رسم اولین رأس",
+    "continueLine": "کلیک برای ادامه رسم",
+    "finishLine": "کلیک روی هر نشان موجود برای پایان",
+    "finishPoly": "کلیک روی اولین نشان برای پایان",
+    "finishRect": "کلیک برای پایان",
+    "startCircle": "کلیک برای رسم مرکز دایره",
+    "finishCircle": "کلیک برای پایان رسم دایره",
+    "placeCircleMarker": "کلیک برای رسم نشان دایره"
+  },
+  "actions": {
+    "finish": "پایان",
+    "cancel": "لفو",
+    "removeLastVertex": "حذف آخرین رأس"
+  },
+  "buttonTitles": {
+    "drawMarkerButton": "درج نشان",
+    "drawPolyButton": "رسم چندضلعی",
+    "drawLineButton": "رسم خط",
+    "drawCircleButton": "رسم دایره",
+    "drawRectButton": "رسم چهارضلعی",
+    "editButton": "ویرایش لایه‌هل",
+    "dragButton": "جابجایی لایه‌ها",
+    "cutButton": "برش لایه‌ها",
+    "deleteButton": "حذف لایه‌ها",
+    "drawCircleMarkerButton": "رسم نشان دایره",
+    "snappingButton": "نشانگر را به لایه ها و رئوس دیگر بکشید",
+    "pinningButton": "رئوس مشترک را با هم پین کنید"
+  }
+}

--- a/src/assets/translations/index.js
+++ b/src/assets/translations/index.js
@@ -18,6 +18,7 @@ import el from './el.json';
 import hu from './hu.json';
 import da from './da.json';
 import no from './no.json';
+import fa from './fa.json';
 
 export default {
   en,
@@ -37,5 +38,6 @@ export default {
   el,
   hu,
   da,
-  no
+  no,
+  fa
 };


### PR DESCRIPTION
Thanks to @SadraParandeh 

Note: this is a RTL Language #618

There is a Bug in the Leaflet Core Leaflet/Leaflet#7201 with RTL and Tooltips.
To work this have to be added in the CSS:
```
.leaflet-tooltip-pane > * {
    direction: rtl;
}
.leaflet-tooltip-pane {
    direction: ltr;
}
```