### PR TITLE
Changed the reference of the Utils functions to the global one

### DIFF
--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -1,7 +1,6 @@
 import Draw from './L.PM.Draw';
 
 import {destinationOnLine, getTranslation} from '../helpers';
-import Utils from "../L.PM.Utils";
 
 Draw.Circle = Draw.extend({
   initialize(map) {
@@ -88,7 +87,7 @@ Draw.Circle = Draw.extend({
     this._otherSnapLayers = [];
 
     // fire drawstart event
-    Utils._fireEvent(this._map,'pm:drawstart', {
+    L.PM.Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -125,7 +124,7 @@ Draw.Circle = Draw.extend({
     }
 
     // fire drawend event
-    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
+    L.PM.Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   enabled() {
@@ -210,7 +209,7 @@ Draw.Circle = Draw.extend({
         getTranslation('tooltips.finishCircle')
       );
 
-      Utils._fireEvent(this._layer,'pm:centerplaced', {
+      L.PM.Utils._fireEvent(this._layer,'pm:centerplaced', {
         workingLayer: this._layer,
         latlng,
         shape: this._shape
@@ -256,7 +255,7 @@ Draw.Circle = Draw.extend({
     }
 
     // fire the pm:create event and pass shape and layer
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: circleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -1,7 +1,5 @@
 import Draw from './L.PM.Draw';
-
 import {destinationOnLine, getTranslation } from '../helpers';
-import Utils from "../L.PM.Utils";
 
 Draw.CircleMarker = Draw.Marker.extend({
   initialize(map) {
@@ -122,7 +120,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     this._layer.bringToBack();
 
     // fire drawstart event
-    Utils._fireEvent(this._map,'pm:drawstart', {
+    L.PM.Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -174,7 +172,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire drawend event
-    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
+    L.PM.Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   _placeCenterMarker(e) {
@@ -208,7 +206,7 @@ Draw.CircleMarker = Draw.Marker.extend({
         getTranslation('tooltips.finishCircle')
       );
 
-      Utils._fireEvent(this._layer,'pm:centerplaced', {
+      L.PM.Utils._fireEvent(this._layer,'pm:centerplaced', {
         shape: this._shape,
         workingLayer: this._layer,
         latlng,
@@ -281,7 +279,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire the pm:create event and pass shape and marker
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       marker, // DEPRECATED
       layer: marker,
@@ -328,7 +326,7 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     // fire the pm:create event and pass shape and layer
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: circleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -2,7 +2,6 @@ import lineIntersect from "@turf/line-intersect";
 import lineSplit from "@turf/line-split";
 import booleanContains from "@turf/boolean-contains";
 import get from "lodash/get";
-import Utils from "../L.PM.Utils";
 import Draw from './L.PM.Draw';
 import {difference, flattenPolyline, groupToMultiLineString, intersect} from "../helpers/turfHelper";
 
@@ -39,21 +38,21 @@ Draw.Cut = Draw.Polygon.extend({
 
     this._editedLayers.forEach(({layer, originalLayer}) =>{
       // fire pm:cut on the cutted layer
-      Utils._fireEvent(originalLayer,'pm:cut', {
+      L.PM.Utils._fireEvent(originalLayer,'pm:cut', {
         shape: this._shape,
         layer,
         originalLayer,
       });
 
       // fire pm:cut on the map
-      Utils._fireEvent(this._map,'pm:cut', {
+      L.PM.Utils._fireEvent(this._map,'pm:cut', {
         shape: this._shape,
         layer,
         originalLayer,
       });
 
       // fire edit event after cut
-      Utils._fireEvent(originalLayer,'pm:edit', { layer: originalLayer, shape: originalLayer.pm.getShape()});
+      L.PM.Utils._fireEvent(originalLayer,'pm:edit', { layer: originalLayer, shape: originalLayer.pm.getShape()});
     });
     this._editedLayers = [];
 
@@ -113,7 +112,7 @@ Draw.Cut = Draw.Polygon.extend({
             if (closest && closest.segment && closest.distance < this.options.snapDistance) {
               const {segment} = closest;
               if (segment && segment.length === 2) {
-                const {indexPath, parentPath, newIndex} = Utils._getIndexFromSegment(coords, segment);
+                const {indexPath, parentPath, newIndex} = L.PM.Utils._getIndexFromSegment(coords, segment);
                 // define the coordsRing that is edited
                 const coordsRing = indexPath.length > 1 ? get(coords, parentPath) : coords;
                 coordsRing.splice(newIndex, 0, latlng);

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -1,6 +1,5 @@
 import kinks from '@turf/kinks';
 import Draw from './L.PM.Draw';
-import Utils from "../L.PM.Utils";
 
 import { getTranslation } from '../helpers';
 
@@ -96,7 +95,7 @@ Draw.Line = Draw.extend({
 
 
     // fire drawstart event
-    Utils._fireEvent(this._map,'pm:drawstart', {
+    L.PM.Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -138,7 +137,7 @@ Draw.Line = Draw.extend({
     }
 
     // fire drawend event
-    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
+    L.PM.Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
 
   },
@@ -261,7 +260,7 @@ Draw.Line = Draw.extend({
 
     this._hintline.setLatLngs([latlng, latlng]);
 
-    Utils._fireEvent(this._layer,'pm:vertexadded', {
+    L.PM.Utils._fireEvent(this._layer,'pm:vertexadded', {
       shape: this._shape,
       workingLayer: this._layer,
       marker: newMarker,
@@ -321,7 +320,7 @@ Draw.Line = Draw.extend({
     polylineLayer.addTo(this._map.pm._getContainingLayer());
 
     // fire the pm:create event and pass shape and layer
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: polylineLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -1,6 +1,5 @@
 import Draw from './L.PM.Draw';
 import { getTranslation } from '../helpers';
-import Utils from "../L.PM.Utils";
 
 Draw.Marker = Draw.extend({
   initialize(map) {
@@ -58,7 +57,7 @@ Draw.Marker = Draw.extend({
     }
 
     // fire drawstart event
-    Utils._fireEvent(this._map,'pm:drawstart', {
+    L.PM.Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -99,7 +98,7 @@ Draw.Marker = Draw.extend({
     }
 
     // fire drawend event
-    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
+    L.PM.Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
   },
   enabled() {
@@ -164,7 +163,7 @@ Draw.Marker = Draw.extend({
     }
 
     // fire the pm:create event and pass shape and marker
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       marker, // DEPRECATED
       layer: marker,

--- a/src/js/Draw/L.PM.Draw.Polygon.js
+++ b/src/js/Draw/L.PM.Draw.Polygon.js
@@ -1,5 +1,4 @@
 import Draw from './L.PM.Draw';
-import Utils from "../L.PM.Utils";
 
 import { getTranslation } from '../helpers';
 
@@ -79,7 +78,7 @@ Draw.Polygon = Draw.Line.extend({
     polygonLayer.addTo(this._map.pm._getContainingLayer());
 
     // fire the pm:create event and pass shape and layer
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: polygonLayer,
     });

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -1,6 +1,4 @@
 import Draw from './L.PM.Draw';
-import Utils from "../L.PM.Utils";
-
 import { getTranslation } from '../helpers';
 
 Draw.Rectangle = Draw.extend({
@@ -99,7 +97,7 @@ Draw.Rectangle = Draw.extend({
     this._otherSnapLayers = [];
 
     // fire drawstart event
-    Utils._fireEvent(this._map,'pm:drawstart', {
+    L.PM.Utils._fireEvent(this._map,'pm:drawstart', {
       shape: this._shape,
       workingLayer: this._layer,
     });
@@ -135,7 +133,7 @@ Draw.Rectangle = Draw.extend({
       this._cleanupSnapping();
     }
     // fire drawend event
-    Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
+    L.PM.Utils._fireEvent(this._map,'pm:drawend', { shape: this._shape });
     this._setGlobalDrawMode();
 
   },
@@ -260,7 +258,7 @@ Draw.Rectangle = Draw.extend({
     rectangleLayer.addTo(this._map.pm._getContainingLayer());
 
     // fire the pm:create event and pass shape and layer
-    Utils._fireEvent(this._map,'pm:create', {
+    L.PM.Utils._fireEvent(this._map,'pm:create', {
       shape: this._shape,
       layer: rectangleLayer,
     });

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -1,5 +1,4 @@
 import SnapMixin from '../Mixins/Snapping';
-import Utils from "../L.PM.Utils";
 
 const Draw = L.Class.extend({
   includes: [SnapMixin],
@@ -103,26 +102,26 @@ const Draw = L.Class.extend({
   _setGlobalDrawMode() {
     // extended to all PM.Draw shapes
     if (this._shape === "Cut") {
-      Utils._fireEvent(this._map,'pm:globalcutmodetoggled', {
+      L.PM.Utils._fireEvent(this._map,'pm:globalcutmodetoggled', {
         enabled: !!this._enabled,
         map: this._map,
       });
     } else {
-      Utils._fireEvent(this._map,'pm:globaldrawmodetoggled', {
+      L.PM.Utils._fireEvent(this._map,'pm:globaldrawmodetoggled', {
         enabled: this._enabled,
         shape: this._shape,
         map: this._map,
       });
     }
 
-    const layers = Utils.findLayers(this._map);
+    const layers = L.PM.Utils.findLayers(this._map);
     if (this._enabled) {
       layers.forEach((layer) => {
-        Utils.disablePopup(layer);
+        L.PM.Utils.disablePopup(layer);
       })
     } else {
       layers.forEach((layer) => {
-        Utils.enablePopup(layer);
+        L.PM.Utils.enablePopup(layer);
       })
     }
   },

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -1,5 +1,4 @@
 import Edit from './L.PM.Edit';
-import Utils from "../L.PM.Utils";
 import {destinationOnLine} from "../helpers";
 
 Edit.Circle = Edit.extend({
@@ -36,7 +35,7 @@ Edit.Circle = Edit.extend({
     // create polygon around the circle border
     this._updateHiddenPolyCircle();
 
-    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // if it's not enabled, it doesn't need to be disabled
@@ -63,11 +62,11 @@ Edit.Circle = Edit.extend({
 
 
     if (this._layerEdited) {
-      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
+      L.PM.Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
 
-    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     return true;
   },
   enabled() {
@@ -182,7 +181,7 @@ Edit.Circle = Edit.extend({
 
     this._updateHiddenPolyCircle();
 
-    Utils._fireEvent(this._layer,'pm:centerplaced', {
+    L.PM.Utils._fireEvent(this._layer,'pm:centerplaced', {
       layer: this._layer,
       latlng: center,
       shape: this.getShape()
@@ -222,7 +221,7 @@ Edit.Circle = Edit.extend({
     this._layer.off('pm:dragstart', this._unsnap, this);
   },
   _onMarkerDragStart(e) {
-    Utils._fireEvent(this._layer,'pm:markerdragstart', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -230,7 +229,7 @@ Edit.Circle = Edit.extend({
     });
   },
   _onMarkerDrag(e) {
-    Utils._fireEvent(this._layer,'pm:markerdrag', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -242,7 +241,7 @@ Edit.Circle = Edit.extend({
     this._fireEdit();
 
     // fire markerdragend event
-    Utils._fireEvent(this._layer,'pm:markerdragend', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -251,23 +250,23 @@ Edit.Circle = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   _fireDragStart() {
-    Utils._fireEvent(this._layer,'pm:dragstart', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:dragstart', { layer: this._layer, shape: this.getShape() });
   },
   _fireDrag(e) {
-    Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
+    L.PM.Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
-    Utils._fireEvent(this._layer,'pm:dragend', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:dragend', { layer: this._layer, shape: this.getShape() });
   },
   _updateHiddenPolyCircle() {
     if (this._hiddenPolyCircle) {
-      this._hiddenPolyCircle.setLatLngs(Utils.circleToPolygon(this._layer, 200).getLatLngs());
+      this._hiddenPolyCircle.setLatLngs(L.PM.Utils.circleToPolygon(this._layer, 200).getLatLngs());
     } else {
-      this._hiddenPolyCircle = Utils.circleToPolygon(this._layer, 200);
+      this._hiddenPolyCircle = L.PM.Utils.circleToPolygon(this._layer, 200);
     }
 
     if (!this._hiddenPolyCircle._parentCopy) {

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -1,5 +1,4 @@
 import Edit from './L.PM.Edit';
-import Utils from "../L.PM.Utils";
 import {destinationOnLine} from "../helpers";
 
 Edit.CircleMarker = Edit.extend({
@@ -36,7 +35,7 @@ Edit.CircleMarker = Edit.extend({
     // create polygon around the circle border
     this._updateHiddenPolyCircle();
 
-    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // prevent disabling if layer is being dragged
@@ -70,10 +69,10 @@ Edit.CircleMarker = Edit.extend({
     // only fire events if it was enabled before
     if (this.enabled()) {
       if (this._layerEdited) {
-        Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
+        L.PM.Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
       }
       this._layerEdited = false;
-      Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
+      L.PM.Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     }
 
     layer.pm._enabled = false;
@@ -217,7 +216,7 @@ Edit.CircleMarker = Edit.extend({
 
     this._updateHiddenPolyCircle();
 
-    Utils._fireEvent(this._layer,'pm:centerplaced', {
+    L.PM.Utils._fireEvent(this._layer,'pm:centerplaced', {
       layer: this._layer,
       latlng: center,
       shape: this.getShape()
@@ -263,14 +262,14 @@ Edit.CircleMarker = Edit.extend({
       this.disable();
     }
     this._layer.remove();
-    Utils._fireEvent(this._layer,'pm:remove', { layer: this._layer, shape: this.getShape() });
-    Utils._fireEvent(this._map,'pm:remove', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:remove', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._map,'pm:remove', { layer: this._layer, shape: this.getShape() });
   },
   _onDragStart(){
     this._map.pm.Draw.CircleMarker._layerIsDragging = true;
   },
   _onMarkerDragStart(e) {
-    Utils._fireEvent(this._layer,'pm:markerdragstart', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragstart', {
       markerEvent: e,
       layer: this._layer,
       shape: this.getShape(),
@@ -278,7 +277,7 @@ Edit.CircleMarker = Edit.extend({
     });
   },
   _onMarkerDrag(e) {
-    Utils._fireEvent(this._layer,'pm:markerdrag', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -287,7 +286,7 @@ Edit.CircleMarker = Edit.extend({
   },
   _onMarkerDragEnd(e) {
     this._map.pm.Draw.CircleMarker._layerIsDragging = false;
-    Utils._fireEvent(this._layer,'pm:markerdragend', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -296,7 +295,7 @@ Edit.CircleMarker = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   // _initSnappableMarkers when option editable is not true
@@ -333,9 +332,9 @@ Edit.CircleMarker = Edit.extend({
       _layer.setRadius(radius);
 
       if (this._hiddenPolyCircle) {
-        this._hiddenPolyCircle.setLatLngs(Utils.circleToPolygon(_layer, 200).getLatLngs());
+        this._hiddenPolyCircle.setLatLngs(L.PM.Utils.circleToPolygon(_layer, 200).getLatLngs());
       } else {
-        this._hiddenPolyCircle = Utils.circleToPolygon(_layer, 200);
+        this._hiddenPolyCircle = L.PM.Utils.circleToPolygon(_layer, 200);
       }
 
       if (!this._hiddenPolyCircle._parentCopy) {

--- a/src/js/Edit/L.PM.Edit.ImageOverlay.js
+++ b/src/js/Edit/L.PM.Edit.ImageOverlay.js
@@ -1,5 +1,4 @@
 import Edit from './L.PM.Edit';
-import Utils from "../L.PM.Utils";
 
 Edit.ImageOverlay = Edit.extend({
   _shape: 'ImageOverlay',
@@ -38,7 +37,7 @@ Edit.ImageOverlay = Edit.extend({
     // create markers for four corners of ImageOverlay
     this._otherSnapLayers = L.PM.Edit.Rectangle.prototype._findCorners.apply(this);
 
-    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(layer = this._layer) {
     // prevent disabling if layer is being dragged
@@ -56,10 +55,10 @@ Edit.ImageOverlay = Edit.extend({
     // only fire events if it was enabled before
     if (!this.enabled()) {
       if (this._layerEdited) {
-        Utils._fireEvent(layer,'pm:update', { layer, shape: this.getShape() });
+        L.PM.Utils._fireEvent(layer,'pm:update', { layer, shape: this.getShape() });
       }
       this._layerEdited = false;
-      Utils._fireEvent(layer,'pm:disable', { layer, shape: this.getShape() });
+      L.PM.Utils._fireEvent(layer,'pm:disable', { layer, shape: this.getShape() });
     }
 
     this._layer.off('contextmenu', this._removeMarker, this);
@@ -68,7 +67,7 @@ Edit.ImageOverlay = Edit.extend({
   },
   _fireEdit() {
     // fire edit event
-    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
 });

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -2,7 +2,6 @@ import kinks from '@turf/kinks';
 import lineIntersect from '@turf/line-intersect';
 import get from 'lodash/get';
 import Edit from './L.PM.Edit';
-import Utils from '../L.PM.Utils';
 import { isEmptyDeep, removeEmptyCoordRings } from '../helpers';
 
 import MarkerLimits from '../Mixins/MarkerLimits';
@@ -69,7 +68,7 @@ Edit.Line = Edit.extend({
     }else{
       this.cachedColor = undefined;
     }
-    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable(poly = this._layer) {
     // if it's not enabled, it doesn't need to be disabled
@@ -106,10 +105,10 @@ Edit.Line = Edit.extend({
     }
 
     if (this._layerEdited) {
-      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
+      L.PM.Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
-    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
     return true;
   },
   enabled() {
@@ -210,7 +209,7 @@ Edit.Line = Edit.extend({
       return false;
     }
 
-    const latlng = Utils.calcMiddleLatLng(
+    const latlng = L.PM.Utils.calcMiddleLatLng(
       this._map,
       leftM.getLatLng(),
       rightM.getLatLng()
@@ -303,7 +302,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
 
-    Utils._fireEvent(this._layer,'pm:vertexadded', {
+    L.PM.Utils._fireEvent(this._layer,'pm:vertexadded', {
       layer: this._layer,
       marker: newM,
       indexPath: this.findDeepMarkerIndex(this._markers, newM).indexPath,
@@ -357,7 +356,7 @@ Edit.Line = Edit.extend({
       }
 
       // fire intersect event
-      Utils._fireEvent(this._layer,'pm:intersect', {
+      L.PM.Utils._fireEvent(this._layer,'pm:intersect', {
         layer: this._layer,
         intersection: kinks(this._layer.toGeoJSON(15)),
         shape: this.getShape()
@@ -528,7 +527,7 @@ Edit.Line = Edit.extend({
     this._fireEdit();
 
     // fire vertex removal event
-    Utils._fireEvent(this._layer,'pm:vertexremoved', {
+    L.PM.Utils._fireEvent(this._layer,'pm:vertexremoved', {
       layer: this._layer,
       marker,
       indexPath,
@@ -632,7 +631,7 @@ Edit.Line = Edit.extend({
     const marker = e.target;
     const { indexPath } = this.findDeepMarkerIndex(this._markers, marker);
 
-    Utils._fireEvent(this._layer,'pm:markerdragstart', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       indexPath,
@@ -699,7 +698,7 @@ Edit.Line = Edit.extend({
     const nextMarkerLatLng = markerArr[nextMarkerIndex].getLatLng();
 
     if (marker._middleMarkerNext) {
-      const middleMarkerNextLatLng = Utils.calcMiddleLatLng(
+      const middleMarkerNextLatLng = L.PM.Utils.calcMiddleLatLng(
         this._map,
         markerLatLng,
         nextMarkerLatLng
@@ -708,7 +707,7 @@ Edit.Line = Edit.extend({
     }
 
     if (marker._middleMarkerPrev) {
-      const middleMarkerPrevLatLng = Utils.calcMiddleLatLng(
+      const middleMarkerPrevLatLng = L.PM.Utils.calcMiddleLatLng(
         this._map,
         markerLatLng,
         prevMarkerLatLng
@@ -720,7 +719,7 @@ Edit.Line = Edit.extend({
     if (!this.options.allowSelfIntersection) {
       this._handleLayerStyle();
     }
-    Utils._fireEvent(this._layer,'pm:markerdrag', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -731,7 +730,7 @@ Edit.Line = Edit.extend({
     const marker = e.target;
     const { indexPath } = this.findDeepMarkerIndex(this._markers, marker);
 
-    Utils._fireEvent(this._layer,'pm:markerdragend', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       indexPath,
@@ -767,7 +766,7 @@ Edit.Line = Edit.extend({
     const vertex = e.target;
     const { indexPath } = this.findDeepMarkerIndex(this._markers, vertex);
 
-    Utils._fireEvent(this._layer,'pm:vertexclick', {
+    L.PM.Utils._fireEvent(this._layer,'pm:vertexclick', {
       layer: this._layer,
       markerEvent: e,
       indexPath,
@@ -777,6 +776,6 @@ Edit.Line = Edit.extend({
   _fireEdit() {
     // fire edit event
     this._layerEdited = true;
-    Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:edit', { layer: this._layer, shape: this.getShape() });
   },
 });

--- a/src/js/Edit/L.PM.Edit.Marker.js
+++ b/src/js/Edit/L.PM.Edit.Marker.js
@@ -1,5 +1,4 @@
 import Edit from './L.PM.Edit';
-import Utils from "../L.PM.Utils";
 
 Edit.Marker = Edit.extend({
   _shape: 'Marker',
@@ -22,7 +21,7 @@ Edit.Marker = Edit.extend({
     this.applyOptions();
     this._enabled = true;
 
-    Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:enable', { layer: this._layer, shape: this.getShape() });
   },
   disable() {
     this._enabled = false;
@@ -32,10 +31,10 @@ Edit.Marker = Edit.extend({
 
     this._layer.off('contextmenu', this._removeMarker, this);
 
-    Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._layer,'pm:disable', { layer: this._layer, shape: this.getShape() });
 
     if (this._layerEdited) {
-      Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
+      L.PM.Utils._fireEvent(this._layer,'pm:update', { layer: this._layer, shape: this.getShape() });
     }
     this._layerEdited = false;
   },
@@ -70,14 +69,14 @@ Edit.Marker = Edit.extend({
     const marker = e.target;
     marker.remove();
     // TODO: find out why this is fired manually, shouldn't it be catched by L.PM.Map 'layerremove'?
-    Utils._fireEvent(marker,'pm:remove', { layer: marker, shape: this.getShape() });
-    Utils._fireEvent(this._map,'pm:remove', { layer: marker, shape: this.getShape() });
+    L.PM.Utils._fireEvent(marker,'pm:remove', { layer: marker, shape: this.getShape() });
+    L.PM.Utils._fireEvent(this._map,'pm:remove', { layer: marker, shape: this.getShape() });
   },
   _onDragEnd(e) {
     const marker = e.target;
 
     // fire the pm:edit event and pass shape and marker
-    Utils._fireEvent(marker,'pm:edit', { layer: this._layer, shape: this.getShape() });
+    L.PM.Utils._fireEvent(marker,'pm:edit', { layer: this._layer, shape: this.getShape() });
     this._layerEdited = true;
   },
   // overwrite initSnappableMarkers from Snapping.js Mixin

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -2,7 +2,6 @@
 // https://github.com/Leaflet/Leaflet.draw/blob/master/src/edit/handler/Edit.Rectangle.js
 
 import Edit from './L.PM.Edit';
-import Utils from "../L.PM.Utils";
 
 Edit.Rectangle = Edit.Polygon.extend({
   _shape: 'Rectangle',
@@ -87,7 +86,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // (Without this, it's occasionally possible for a marker to get stuck as 'snapped,' which prevents Rectangle resizing)
     draggedMarker._snapped = false;
 
-    Utils._fireEvent(this._layer,'pm:markerdragstart', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragstart', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -109,7 +108,7 @@ Edit.Rectangle = Edit.Polygon.extend({
       this._adjustRectangleForMarkerMove(draggedMarker);
     }
 
-    Utils._fireEvent(this._layer,'pm:markerdrag', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdrag', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),
@@ -131,7 +130,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // Update bounding box
     this._layer.setLatLngs(corners);
 
-    Utils._fireEvent(this._layer,'pm:markerdragend', {
+    L.PM.Utils._fireEvent(this._layer,'pm:markerdragend', {
       layer: this._layer,
       markerEvent: e,
       shape: this.getShape(),

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -1,12 +1,8 @@
 import merge from 'lodash/merge';
 import translations from '../assets/translations';
-import Utils from './L.PM.Utils'
-
 import GlobalEditMode from './Mixins/Modes/Mode.Edit';
 import GlobalDragMode from './Mixins/Modes/Mode.Drag';
 import GlobalRemovalMode from './Mixins/Modes/Mode.Removal';
-
-const { findLayers } = Utils
 
 const Map = L.Class.extend({
   includes: [GlobalEditMode, GlobalDragMode, GlobalRemovalMode],
@@ -36,7 +32,7 @@ const Map = L.Class.extend({
 
     L.PM.activeLang = lang;
     this.map.pm.Toolbar.reinit();
-    Utils._fireEvent(this.map,"pm:langchange", {
+    L.PM.Utils._fireEvent(this.map,"pm:langchange", {
       oldLang,
       activeLang: lang,
       fallback,
@@ -106,7 +102,7 @@ const Map = L.Class.extend({
     }
 
     // enable options for Editing
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
     layers.forEach(layer => {
       layer.pm.setOptions(options);
     });
@@ -118,7 +114,7 @@ const Map = L.Class.extend({
     this.globalOptions = options;
   },
   applyGlobalOptions() {
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
     layers.forEach(layer => {
       if (layer.pm.enabled()) {
         layer.pm.applyOptions();
@@ -141,7 +137,7 @@ const Map = L.Class.extend({
     return this.Draw.Cut.disable();
   },
   getGeomanLayers(asGroup = false){
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
     if(!asGroup) {
       return layers;
     }
@@ -153,7 +149,7 @@ const Map = L.Class.extend({
     return group;
   },
   getGeomanDrawLayers(asGroup = false){
-    const layers = findLayers(this.map).filter(l => l._drawnByGeoman === true);
+    const layers = L.PM.Utils.findLayers(this.map).filter(l => l._drawnByGeoman === true);
     if(!asGroup) {
       return layers;
     }

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -1,5 +1,3 @@
-import Utils from "../L.PM.Utils";
-
 const DragMixin = {
   enableLayerDrag() {
     // before enabling layer drag, disable layer editing
@@ -223,16 +221,16 @@ const DragMixin = {
     this._fireDrag(e);
   },
   _fireDragStart() {
-    Utils._fireEvent(this._layer,'pm:dragstart', {
+    L.PM.Utils._fireEvent(this._layer,'pm:dragstart', {
       layer: this._layer,
       shape: this.getShape()
     });
   },
   _fireDrag(e) {
-    Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
+    L.PM.Utils._fireEvent(this._layer,'pm:drag', Object.assign({},e, {shape:this.getShape()}));
   },
   _fireDragEnd() {
-    Utils._fireEvent(this._layer,'pm:dragend', {
+    L.PM.Utils._fireEvent(this._layer,'pm:dragend', {
       layer: this._layer,
       shape: this.getShape()
     });

--- a/src/js/Mixins/Modes/Mode.Drag.js
+++ b/src/js/Mixins/Modes/Mode.Drag.js
@@ -1,10 +1,7 @@
-import Utils from '../../L.PM.Utils'
-
-const { findLayers } = Utils;
 
 const GlobalDragMode = {
   enableGlobalDragMode() {
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
 
     this._globalDragMode = true;
 
@@ -25,7 +22,7 @@ const GlobalDragMode = {
     this._fireDragModeEvent(true);
   },
   disableGlobalDragMode() {
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
 
     this._globalDragMode = false;
 
@@ -65,7 +62,7 @@ const GlobalDragMode = {
     }
   },
   _fireDragModeEvent(enabled) {
-    Utils._fireEvent(this.map,'pm:globaldragmodetoggled', {
+    L.PM.Utils._fireEvent(this.map,'pm:globaldragmodetoggled', {
       enabled,
       map: this.map,
     });

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -1,8 +1,4 @@
 // this mixin adds a global edit mode to the map
-import Utils from '../../L.PM.Utils'
-
-const { findLayers } = Utils;
-
 const GlobalEditMode = {
   _globalEditMode: false,
   enableGlobalEditMode(o) {
@@ -17,7 +13,7 @@ const GlobalEditMode = {
     this.Toolbar.toggleButton('editMode', status);
 
     // find all layers handled by leaflet-geoman
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
 
     // enable all layers
     layers.forEach(layer => {
@@ -40,7 +36,7 @@ const GlobalEditMode = {
     const status = false;
 
     // find all layers handles by leaflet-geoman
-    const layers = findLayers(this.map);
+    const layers = L.PM.Utils.findLayers(this.map);
 
     // disable all layers
     layers.forEach(layer => {
@@ -99,7 +95,7 @@ const GlobalEditMode = {
     this._addedLayers.push(layer);
   },
   _fireEditModeEvent(enabled) {
-    Utils._fireEvent(this.map,'pm:globaleditmodetoggled', {
+    L.PM.Utils._fireEvent(this.map,'pm:globaleditmodetoggled', {
       enabled,
       map: this.map,
     });

--- a/src/js/Mixins/Modes/Mode.Removal.js
+++ b/src/js/Mixins/Modes/Mode.Removal.js
@@ -1,5 +1,3 @@
-import Utils from "../../L.PM.Utils";
-
 const GlobalRemovalMode = {
   enableGlobalRemovalMode() {
     const isRelevant = layer =>
@@ -70,7 +68,7 @@ const GlobalRemovalMode = {
     }
   },
   _fireRemovalModeEvent(enabled) {
-    Utils._fireEvent(this.map,'pm:globalremovalmodetoggled', {
+    L.PM.Utils._fireEvent(this.map,'pm:globalremovalmodetoggled', {
       enabled,
       map: this.map,
     });
@@ -86,11 +84,11 @@ const GlobalRemovalMode = {
       layer.removeFrom(this.map.pm._getContainingLayer());
       layer.remove();
       if(layer instanceof L.LayerGroup){
-        Utils._fireEvent(layer,'pm:remove', { layer, shape: undefined });
-        Utils._fireEvent(this.map,'pm:remove', { layer, shape: undefined });
+        L.PM.Utils._fireEvent(layer,'pm:remove', { layer, shape: undefined });
+        L.PM.Utils._fireEvent(this.map,'pm:remove', { layer, shape: undefined });
       }else{
-        Utils._fireEvent(layer,'pm:remove', { layer, shape: layer.pm.getShape() });
-        Utils._fireEvent(this.map,'pm:remove', { layer, shape: layer.pm.getShape() });
+        L.PM.Utils._fireEvent(layer,'pm:remove', { layer, shape: layer.pm.getShape() });
+        L.PM.Utils._fireEvent(this.map,'pm:remove', { layer, shape: layer.pm.getShape() });
       }
 
     }

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -1,4 +1,3 @@
-import Utils from '../L.PM.Utils';
 import {isEmptyDeep, prioritiseSort} from "../helpers";
 
 const SnapMixin = {
@@ -119,8 +118,8 @@ const SnapMixin = {
       distance: closestLayer.distance,
     };
 
-    Utils._fireEvent(eventInfo.marker,'pm:snapdrag', eventInfo);
-    Utils._fireEvent(this._layer,'pm:snapdrag', eventInfo);
+    L.PM.Utils._fireEvent(eventInfo.marker,'pm:snapdrag', eventInfo);
+    L.PM.Utils._fireEvent(this._layer,'pm:snapdrag', eventInfo);
 
     if (closestLayer.distance < minDistance) {
       // snap the marker
@@ -132,8 +131,8 @@ const SnapMixin = {
 
       const triggerSnap = () => {
         this._snapLatLng = snapLatLng;
-        Utils._fireEvent(marker,'pm:snap', eventInfo);
-        Utils._fireEvent(this._layer,'pm:snap', eventInfo);
+        L.PM.Utils._fireEvent(marker,'pm:snap', eventInfo);
+        L.PM.Utils._fireEvent(this._layer,'pm:snap', eventInfo);
       };
 
       // check if the snapping position differs from the last snap
@@ -154,8 +153,8 @@ const SnapMixin = {
       marker._snapped = false;
 
       // and fire unsnap event
-      Utils._fireEvent(eventInfo.marker,'pm:unsnap', eventInfo);
-      Utils._fireEvent(this._layer,'pm:unsnap', eventInfo);
+      L.PM.Utils._fireEvent(eventInfo.marker,'pm:unsnap', eventInfo);
+      L.PM.Utils._fireEvent(this._layer,'pm:unsnap', eventInfo);
     }
 
     return true;
@@ -393,7 +392,7 @@ const SnapMixin = {
 
     // snap to middle (M) of segment if option is enabled
     if (this.options.snapMiddle) {
-      const M = Utils.calcMiddleLatLng(map, A, B);
+      const M = L.PM.Utils.calcMiddleLatLng(map, A, B);
       const distanceMC = this._getDistance(map, M, C);
 
       if (distanceMC < distanceAC && distanceMC < distanceBC) {

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -1,5 +1,4 @@
 import { getTranslation } from '../helpers';
-import Utils from "../L.PM.Utils";
 
 const PMButton = L.Control.extend({
   options: {
@@ -160,7 +159,7 @@ const PMButton = L.Control.extend({
                 break;
               }
             }
-            Utils._fireEvent(this._map,'pm:actionclick', {text: action.text, action, btnName, button});
+            L.PM.Utils._fireEvent(this._map,'pm:actionclick', {text: action.text, action, btnName, button});
           };
 
           L.DomEvent.addListener(actionNode, 'click', actionClick, this);
@@ -201,7 +200,7 @@ const PMButton = L.Control.extend({
             break;
           }
         }
-        Utils._fireEvent(this._map,'pm:buttonclick', {btnName, button});
+        L.PM.Utils._fireEvent(this._map,'pm:buttonclick', {btnName, button});
       });
       L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
     }


### PR DESCRIPTION
Now it is possible for the user to overwrite Utils functions. For example for sub libraries.

```
var oldFindLayers = L.PM.Utils.findLayers;
L.PM.Utils.findLayers = function(map){
    var layers = oldFindLayers(map);
    console.log(layers);
    return layers;
}
```