### PR TITLE
SnapList was not removed after removing and adding a layer

### DIFF
--- a/cypress/integration/rectangle.spec.js
+++ b/cypress/integration/rectangle.spec.js
@@ -209,4 +209,27 @@ describe('Draw Rectangle', () => {
       expect(text).to.equal('Popup test');
     })
   });
+
+  it('prevent not correct created snaplist', () => {
+    cy.window().then(({ map }) => {
+      map.on("pm:create",(e)=>{
+        map.removeLayer(e.layer);
+        map.addLayer(e.layer);
+      });
+    });
+
+
+    cy.toolbarButton('rectangle')
+      .click()
+      .closest('.button-container')
+      .should('have.class', 'active');
+
+    cy.get(mapSelector)
+      .click(200, 200)
+      .click(400, 350);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList).to.equal(undefined);
+    });
+  });
 });

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -50,13 +50,20 @@ const SnapMixin = {
       });
     }
   },
+  _handleThrottleSnapping(){
+    // we check if the throttledList is existing, else the function is deleted but the `layeradd` event calls it.
+    // this made problems when layer was removed and added to the map in the `pm:create` event
+    if(this.throttledList){
+      this._createSnapList();
+    }
+  },
   _handleSnapping(e) {
 
     const marker = e.target;
     marker._snapped = false;
 
     if (!this.throttledList) {
-      this.throttledList = L.Util.throttle(this._createSnapList, 100, this);
+      this.throttledList = L.Util.throttle(this._handleThrottleSnapping, 100, this);
     }
 
     // if snapping is disabled via holding ALT during drag, stop right here


### PR DESCRIPTION
The snapList was not generated new when in the `pm:create` event `map.removeLayer(e.layer)` and then `map.addLayer(e.layer)` was called.

The problem was, that the listener `layeradd` on the map was called because of removing and readding the layer in `pm:create` but the listener was fired AFTER drawing was disabled and `_cleanupSnapping` was called. So the result was, that to the drawing layer (`map.pm.Draw.Rectangle._snapList`) was the snapList created. And then when the drawing mode for Rectangle was enabled, it not created the snapList, because it has already one (this can be a old snapping list) 