### PR TITLE
pm:snapdrag fix (after selfIntersection)

### DIFF
--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -756,6 +756,10 @@ Edit.Line = Edit.extend({
       // re-enable markers for the new coords
       this._initMarkers();
 
+      if (this.options.snappable) {
+        this._initSnappableMarkers();
+      }
+
       // check for selfintersection again (mainly to reset the style)
       this._handleLayerStyle();
       return;


### PR DESCRIPTION
Re-init snappable Markers to be sure that pm:snapdrag is fired after selfIntersection is detected

Fix: #800