### PR TITLE
Make layers always snappable with `snapIgnore: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ Some details about a few more powerful options:
 ##### Snapping  
   
 Snap the dragged marker/vertex to other layers for precision drawing.  
+Snapping can be disabled for layers with the layer option `snapIgnore: true`. With `snapIgnore: false` it will be always snappable, also if `pmIgnore` is set.
   
 ![Snapping Options](https://files-r7ezk18qq.now.sh/snapping.gif)  
   

--- a/cypress/integration/rectangle.spec.js
+++ b/cypress/integration/rectangle.spec.js
@@ -232,4 +232,127 @@ describe('Draw Rectangle', () => {
       expect(map.pm.Draw.Rectangle._snapList).to.equal(undefined);
     });
   });
+
+  it('make layer snappable with pmIgnore', () => {
+    // create snapping layer
+    cy.toolbarButton('rectangle')
+      .click()
+      .closest('.button-container')
+      .should('have.class', 'active');
+
+    cy.get(mapSelector)
+      .click(200, 200)
+      .click(400, 350);
+
+    // test 1: snapIgnore: undefined, pmIgnore: undefined, optIn: false --> snappable
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    let layer;
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(1);
+      map.pm.disableDraw();
+      layer = map.pm.getGeomanDrawLayers()[0];
+    });
+
+    // test 2: snapIgnore: true, pmIgnore: undefined, optIn: false --> not snappable
+    cy.window().then(() => {
+      layer.options.snapIgnore = true;
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(0);
+      map.pm.disableDraw();
+    });
+
+    // test 3: snapIgnore: false, pmIgnore: true, optIn: false --> snappable
+    cy.window().then(() => {
+      layer.options.snapIgnore = false;
+      layer.options.pmIgnore = true;
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(1);
+      map.pm.disableDraw();
+    });
+
+    // test 4: snapIgnore: undefined, pmIgnore: true, optIn: false --> not snappable
+    cy.window().then(() => {
+      delete layer.options.snapIgnore;
+      layer.options.pmIgnore = true;
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(0);
+      map.pm.disableDraw();
+    });
+
+
+    // test 5: snapIgnore: undefined, pmIgnore: false, optIn: true --> snappable
+    cy.window().then(({L}) => {
+      delete layer.options.snapIgnore;
+      layer.options.pmIgnore = false;
+      L.PM.setOptIn(true)
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(1);
+      map.pm.disableDraw();
+    });
+
+    // test 6: snapIgnore: undefined, pmIgnore: true, optIn: true --> not snappable
+    cy.window().then(({L}) => {
+      layer.options.pmIgnore = true;
+      L.PM.setOptIn(true)
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(0);
+      map.pm.disableDraw();
+    });
+
+
+    // test 7: snapIgnore: false, pmIgnore: true, optIn: true --> snappable
+    cy.window().then(() => {
+      layer.options.snapIgnore = false;
+    });
+    cy.toolbarButton('rectangle')
+      .click();
+    // click or mousemove is needed to init snapList
+    cy.get(mapSelector)
+      .click(200, 100);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.Draw.Rectangle._snapList.length).to.equal(1);
+      map.pm.disableDraw();
+    });
+  });
 });

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -182,12 +182,18 @@ const SnapMixin = {
           layer instanceof L.Marker ||
           layer instanceof L.CircleMarker ||
           layer instanceof L.ImageOverlay) &&
-        layer.options.snapIgnore !== true &&
-        (
-          (!L.PM.optIn && !layer.options.pmIgnore) || // if optIn is not set / true and pmIgnore is not set / true (default)
-          (L.PM.optIn && layer.options.pmIgnore === false) // if optIn is true and pmIgnore is false
-        )
+        layer.options.snapIgnore !== true
       ) {
+
+        // if snapIgnore === false the layer will be always snappable
+        if(layer.options.snapIgnore === undefined && (
+            (!L.PM.optIn && layer.options.pmIgnore === true) || // if optIn is not set and pmIgnore is true, the layer will be ignored
+            (L.PM.optIn && layer.options.pmIgnore !== false) // if optIn is true and pmIgnore is not false, the layer will be ignored
+          )
+        ){
+          return;
+        }
+
         // adds a hidden polygon which matches the border of the circle
         if ((layer instanceof L.Circle || layer instanceof L.CircleMarker) && layer.pm && layer.pm._hiddenPolyCircle) {
           layers.push(layer.pm._hiddenPolyCircle);


### PR DESCRIPTION
Snapping can be disabled for layers with the layer option `snapIgnore: true`. With `snapIgnore: false` it will be always snappable, also if `pmIgnore` is set.

Fix: #797