### PR TITLE
Some fixes with global modes

### DIFF
--- a/cypress/integration/polygon.spec.js
+++ b/cypress/integration/polygon.spec.js
@@ -1015,12 +1015,29 @@ describe('Draw & Edit Poly', () => {
       .click(180, 230)
       .click(190, 70)
       .click(230, 70)
-      .click(180, 230)
+      .click(180, 230);
 
     cy.window().then(({ map }) => {
       const layer2 = map.pm.getGeomanDrawLayers()[0];
       expect(layer).to.eq(layer2);
     });
+  });
+
+  it('disable Rotate-Mode for layer with allowRotate: false', () => {
+    cy.toolbarButton('polygon').click();
+    cy.get(mapSelector)
+      .click(150, 250)
+      .click(160, 50)
+      .click(250, 50)
+      .click(150, 250);
+
+    cy.window().then(({ map }) => {
+      map.pm.setGlobalOptions({allowRotation: false});
+    });
+
+    cy.toolbarButton('rotate').click();
+
+    cy.hasVertexMarkers(0);
   });
 
   it('cut only certain layers', () => {

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -13,8 +13,6 @@ const Map = L.Class.extend({
     this.Draw = new L.PM.Draw(map);
     this.Toolbar = new L.PM.Toolbar(map);
 
-    this._globalRemovalMode = false;
-
     this.globalOptions = {
       snappable: true,
       layerGroup: undefined,

--- a/src/js/Mixins/Modes/Mode.Drag.js
+++ b/src/js/Mixins/Modes/Mode.Drag.js
@@ -1,9 +1,9 @@
-
 const GlobalDragMode = {
+  _globalDragModeEnabled: false,
   enableGlobalDragMode() {
     const layers = L.PM.Utils.findLayers(this.map);
 
-    this._globalDragMode = true;
+    this._globalDragModeEnabled = true;
 
     layers.forEach(layer => {
       layer.pm.enableLayerDrag();
@@ -17,14 +17,14 @@ const GlobalDragMode = {
     this.map.on('layeradd', this.throttledReInitDrag, this);
 
     // toogle the button in the toolbar if this is called programatically
-    this.Toolbar.toggleButton('dragMode', this._globalDragMode);
+    this.Toolbar.toggleButton('dragMode', this.globalDragModeEnabled());
 
     this._fireGlobalDragModeToggled(true);
   },
   disableGlobalDragMode() {
     const layers = L.PM.Utils.findLayers(this.map);
 
-    this._globalDragMode = false;
+    this._globalDragModeEnabled = false;
 
     layers.forEach(layer => {
       layer.pm.disableLayerDrag();
@@ -34,12 +34,12 @@ const GlobalDragMode = {
     this.map.off('layeradd', this.throttledReInitDrag, this);
 
     // toogle the button in the toolbar if this is called programatically
-    this.Toolbar.toggleButton('dragMode', this._globalDragMode);
+    this.Toolbar.toggleButton('dragMode', this.globalDragModeEnabled());
 
     this._fireGlobalDragModeToggled(false);
   },
   globalDragModeEnabled() {
-    return !!this._globalDragMode;
+    return !!this._globalDragModeEnabled;
   },
   toggleGlobalDragMode() {
     if (this.globalDragModeEnabled()) {

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -1,16 +1,12 @@
 // this mixin adds a global edit mode to the map
 const GlobalEditMode = {
-  _globalEditMode: false,
-  enableGlobalEditMode(o) {
-    const options = {
-      snappable: this._globalSnappingEnabled,
-      ...o
-    };
-
-    const status = true;
+  _globalEditModeEnabled: false,
+  enableGlobalEditMode(options) {
+    // set status
+    this._globalEditModeEnabled = true;
 
     // Set toolbar button to currect status
-    this.Toolbar.toggleButton('editMode', status);
+    this.Toolbar.toggleButton('editMode', this.globalEditModeEnabled());
 
     // find all layers handled by leaflet-geoman
     const layers = L.PM.Utils.findLayers(this.map);
@@ -30,10 +26,12 @@ const GlobalEditMode = {
     // handle layers that are added while in removal mode
     this.map.on('layeradd', this.throttledReInitEdit, this);
 
-    this.setGlobalEditStatus(status);
+    // fire event
+    this._fireGlobalEditModeToggled(true);
   },
   disableGlobalEditMode() {
-    const status = false;
+    // set status
+    this._globalEditModeEnabled = false;
 
     // find all layers handles by leaflet-geoman
     const layers = L.PM.Utils.findLayers(this.map);
@@ -47,22 +45,17 @@ const GlobalEditMode = {
     this.map.off('layeradd', this.throttledReInitEdit, this);
 
     // Set toolbar button to currect status
-    this.Toolbar.toggleButton('editMode', status);
+    this.Toolbar.toggleButton('editMode', this.globalEditModeEnabled());
 
-    this.setGlobalEditStatus(status);
+    // fire event
+    this._fireGlobalEditModeToggled(false);
   },
   // TODO: Remove in the next major release
   globalEditEnabled() {
     return this.globalEditModeEnabled();
   },
   globalEditModeEnabled() {
-    return this._globalEditMode;
-  },
-  setGlobalEditStatus(status) {
-    // set status
-    this._globalEditMode = status;
-    // fire event
-    this._fireGlobalEditModeToggled(this._globalEditMode);
+    return this._globalEditModeEnabled;
   },
   toggleGlobalEditMode(options = this.globalOptions) {
     if (this.globalEditModeEnabled()) {

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -57,6 +57,7 @@ const GlobalEditMode = {
   globalEditModeEnabled() {
     return this._globalEditModeEnabled;
   },
+  // TODO: this should maybe removed, it will overwrite explicit options on the layers
   toggleGlobalEditMode(options = this.globalOptions) {
     if (this.globalEditModeEnabled()) {
       // disable

--- a/src/js/Mixins/Modes/Mode.Removal.js
+++ b/src/js/Mixins/Modes/Mode.Removal.js
@@ -1,6 +1,7 @@
 const GlobalRemovalMode = {
+  _globalRemovalModeEnabled: false,
   enableGlobalRemovalMode() {
-    this._globalRemovalMode = true;
+    this._globalRemovalModeEnabled = true;
     // handle existing layers
     this.map.eachLayer(layer => {
       if (this._isRelevant(layer)) {
@@ -13,16 +14,16 @@ const GlobalRemovalMode = {
       this.throttledReInitRemoval = L.Util.throttle(this.reinitGlobalRemovalMode, 100, this)
     }
 
-    // handle layers that are added while in removal  xmode
+    // handle layers that are added while in removal mode
     this.map.on('layeradd', this.throttledReInitRemoval, this);
 
     // toogle the button in the toolbar if this is called programatically
-    this.Toolbar.toggleButton('deleteLayer', this._globalRemovalMode);
+    this.Toolbar.toggleButton('deleteLayer', this.globalRemovalModeEnabled());
 
     this._fireGlobalRemovalModeToggled(true);
   },
   disableGlobalRemovalMode() {
-    this._globalRemovalMode = false;
+    this._globalRemovalModeEnabled = false;
     this.map.eachLayer(layer => {
       layer.off('click', this.removeLayer, this);
     });
@@ -31,7 +32,7 @@ const GlobalRemovalMode = {
     this.map.off('layeradd', this.throttledReInitRemoval, this);
 
     // toogle the button in the toolbar if this is called programatically
-    this.Toolbar.toggleButton('deleteLayer', this._globalRemovalMode);
+    this.Toolbar.toggleButton('deleteLayer', this.globalRemovalModeEnabled());
 
     this._fireGlobalRemovalModeToggled(false);
   },
@@ -40,7 +41,7 @@ const GlobalRemovalMode = {
     return this.globalRemovalModeEnabled();
   },
   globalRemovalModeEnabled() {
-    return !!this._globalRemovalMode;
+    return !!this._globalRemovalModeEnabled;
   },
   toggleGlobalRemovalMode() {
     // toggle global edit mode

--- a/src/js/Mixins/Modes/Mode.Removal.js
+++ b/src/js/Mixins/Modes/Mode.Removal.js
@@ -4,7 +4,7 @@ const GlobalRemovalMode = {
     this._globalRemovalModeEnabled = true;
     // handle existing layers
     this.map.eachLayer(layer => {
-      if (this._isRelevant(layer)) {
+      if (this._isRelevantForRemoval(layer)) {
         layer.pm.disable();
         layer.on('click', this.removeLayer, this);
       }
@@ -53,7 +53,7 @@ const GlobalRemovalMode = {
   },
   reinitGlobalRemovalMode({ layer }) {
     // do nothing if layer is not handled by leaflet so it doesn't fire unnecessarily
-    if (!this._isRelevant(layer)) {
+    if (!this._isRelevantForRemoval(layer)) {
       return;
     }
 
@@ -67,7 +67,7 @@ const GlobalRemovalMode = {
     const layer = e.target;
     // only remove layer, if it's handled by leaflet-geoman,
     // not a tempLayer and not currently being dragged
-    const removeable = this._isRelevant(layer) && !layer.pm.dragging();
+    const removeable = this._isRelevantForRemoval(layer) && !layer.pm.dragging();
 
     if (removeable) {
       layer.removeFrom(this.map.pm._getContainingLayer());
@@ -81,7 +81,7 @@ const GlobalRemovalMode = {
       }
     }
   },
-  _isRelevant(layer){
+  _isRelevantForRemoval(layer){
     return layer.pm
       && !(layer instanceof L.LayerGroup)
       && (

--- a/src/js/Mixins/Modes/Mode.Rotate.js
+++ b/src/js/Mixins/Modes/Mode.Rotate.js
@@ -4,7 +4,9 @@ const GlobalRotateMode = {
     this._globalRotateModeEnabled = true;
     const layers = L.PM.Utils.findLayers(this.map).filter(l => l instanceof L.Polyline);
     layers.forEach(layer => {
-      layer.pm.enableRotate();
+      if(this._isRelevantForRotate(layer)) {
+        layer.pm.enableRotate();
+      }
     });
 
     if (!this.throttledReInitRotate) {
@@ -43,7 +45,7 @@ const GlobalRotateMode = {
   },
   _reinitGlobalRotateMode({ layer }) {
     // do nothing if layer is not handled by leaflet so it doesn't fire unnecessarily
-    if (!this._isRelevant(layer)) {
+    if (!this._isRelevantForRotate(layer)) {
       return;
     }
 
@@ -53,7 +55,7 @@ const GlobalRotateMode = {
       this.enableGlobalRotateMode();
     }
   },
-  _isRelevant(layer){
+  _isRelevantForRotate(layer){
     return layer.pm
       && !(layer instanceof L.LayerGroup)
       && (


### PR DESCRIPTION
Fix intial snapping bug:
 - if layers already on  map while intializing and then `map.pm.enableGlobalEditMode()` was called, the layers where not able to snap

Add throttle to rotation mode

use public functions instead the internal variable