### PR TITLE
Change Z-IndexOffset on vertex markers - fixes overlapping markers

### DIFF
--- a/cypress/integration/line.spec.js
+++ b/cypress/integration/line.spec.js
@@ -273,4 +273,15 @@ describe('Draw & Edit Line', () => {
       expect(2).to.eq(map.pm.getGeomanDrawLayers().length);
     });
   });
+
+  it('vertex marker overlapping', () => {
+    cy.toolbarButton('polyline').click();
+    cy.get(mapSelector)
+      .click(150, 250)
+      .click(160, 50)
+      .click(250, 50)
+      .click(155, 255);
+
+    cy.hasVertexMarkers(0);
+  });
 });

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -40,6 +40,7 @@ Draw.Circle = Draw.extend({
 
     // this is the hintmarker on the mouse cursor
     this._hintMarker = L.marker([0, 0], {
+      zIndexOffset: 110,
       icon: L.divIcon({ className: 'marker-icon cursor-marker' }),
     });
     this._setPane(this._hintMarker,'vertexPane');

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -46,6 +46,7 @@ Draw.CircleMarker = Draw.Marker.extend({
 
       // this is the hintmarker on the mouse cursor
       this._hintMarker = L.marker([0, 0], {
+        zIndexOffset: 110,
         icon: L.divIcon({ className: 'marker-icon cursor-marker' }),
       });
       this._setPane(this._hintMarker,'vertexPane');

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -35,7 +35,7 @@ Draw.Line = Draw.extend({
 
     // this is the hintmarker on the mouse cursor
     this._hintMarker = L.marker(this._map.getCenter(),{
-      interactive: false, // always vertex marker blow will be triggered from the click event -> finishShape #911
+      interactive: false, // always vertex marker below will be triggered from the click event -> _finishShape #911
       zIndexOffset: 100,
       icon: L.divIcon({ className: 'marker-icon cursor-marker' }),
     });

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -34,7 +34,9 @@ Draw.Line = Draw.extend({
     this._layerGroup.addLayer(this._hintline);
 
     // this is the hintmarker on the mouse cursor
-    this._hintMarker = L.marker(this._map.getCenter(), {
+    this._hintMarker = L.marker(this._map.getCenter(),{
+      interactive: false, // always vertex marker blow will be triggered from the click event -> finishShape #911
+      zIndexOffset: 100,
       icon: L.divIcon({ className: 'marker-icon cursor-marker' }),
     });
     this._setPane(this._hintMarker,'vertexPane');

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -30,7 +30,7 @@ Draw.Rectangle = Draw.extend({
     this._startMarker = L.marker([0, 0], {
       icon: L.divIcon({ className: 'marker-icon rect-start-marker' }),
       draggable: false,
-      zIndexOffset: 100,
+      zIndexOffset: -100,
       opacity: this.options.cursorMarker ? 1 : 0,
     });
     this._setPane(this._startMarker,'vertexPane');
@@ -39,6 +39,7 @@ Draw.Rectangle = Draw.extend({
 
     // this is the hintmarker on the mouse cursor
     this._hintMarker = L.marker([0, 0], {
+      zIndexOffset: 150,
       icon: L.divIcon({ className: 'marker-icon cursor-marker' }),
     });
     this._setPane(this._hintMarker,'vertexPane');


### PR DESCRIPTION
Fix: #911 

Now the click event goes through the hint marker and is fired on the vertex below.
![marker_overlapping](https://user-images.githubusercontent.com/19800037/118716069-b29e8a00-b824-11eb-8b62-4e6db2294292.gif)
