### PR TITLE
Fix TypeScript Issues

### DIFF
--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -21,12 +21,19 @@ declare module 'leaflet' {
     }
 
     /**
-     * Extends built in leaflet layer.
+     * Extends built in leaflet path.
      */
-    interface Layer {
-        pm: PM.PMLayer;
+    interface Path  {
+      pm: PM.PMLayer;
     }
     /**
+     * Extends built in leaflet imageoverlay.
+     */
+    interface ImageOverlay  {
+      pm: PM.PMLayer
+    }
+
+     /**
      * Extends built in leaflet layergroup.
      */
     interface LayerGroup {

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -3,48 +3,51 @@ import * as L from 'leaflet';
 // redeclare module, maintains compatibility with @types/leaflet
 declare module 'leaflet' {
 
-    /** Extends built in leaflet layer options. */
+    /**
+     * Extends built in leaflet Layer Options.
+     */
     interface LayerOptions {
         pmIgnore?: boolean;
         snapIgnore?: boolean;
     }
 
+    /**
+     * Extends built in leaflet Map Options.
+     */
     interface MapOptions {
         pmIgnore?: boolean;
     }
 
     /**
-     * Extends built in leaflet map.
+     * Extends built in leaflet Map.
      */
     interface Map {
         pm: PM.PMMap;
     }
 
     /**
-     * Extends built in leaflet path.
+     * Extends built in leaflet Path.
      */
     interface Path  {
       pm: PM.PMLayer;
     }
     /**
-     * Extends built in leaflet imageoverlay.
+     * Extends built in leaflet ImageOverlay.
      */
     interface ImageOverlay  {
       pm: PM.PMLayer
     }
 
      /**
-     * Extends built in leaflet layergroup.
+     * Extends built in leaflet LayerGroup.
      */
     interface LayerGroup {
         pm: PM.PMLayerGroup;
     }
 
-    interface Polygon {
-        /** Returns true if Line or Polygon has a self intersection. */
-        hasSelfIntersection(): boolean;
-    }
-
+    /**
+     * Extends built in leaflet Polyline.
+     */
     interface Polyline {
         /** Returns true if Line or Polygon has a self intersection. */
         hasSelfIntersection(): boolean;
@@ -496,12 +499,13 @@ declare module 'leaflet' {
             | 'dragMode'
             | 'cutPolygon'
             | 'removalMode'
+            | 'rotateMode'
             | string;
 
         interface PMMapToolbar {
 
             /** Pass an array of button names to reorder the buttons in the Toolbar. */
-            changeControlOrder(order: TOOLBAR_CONTROL_ORDER[]): void;
+            changeControlOrder(order?: TOOLBAR_CONTROL_ORDER[]): void;
 
             /** Receive the current order with. */
             getControlOrder(): TOOLBAR_CONTROL_ORDER[];
@@ -632,7 +636,7 @@ declare module 'leaflet' {
             enableDraw(shape: SUPPORTED_SHAPES, options?: DrawModeOptions): void;
 
             /** disable all drawing */
-            disableDraw(): void;
+            disableDraw(shape?: SUPPORTED_SHAPES): void;
 
             /** Draw */
             Draw: Draw;
@@ -640,8 +644,8 @@ declare module 'leaflet' {
             /** Returns true if global Draw Mode is enabled. false when disabled. */
             globalDrawModeEnabled(): boolean;
 
-            /** Customize the style of the drawn layer. Only for L.Path layers. Shapes can be excluded with a ignoreShapes array in optionsModifier. */
-            setPathOptions(options: L.PathOptions, optionsModifier: { ignoreShapes: SUPPORTED_SHAPES[] }): void;
+            /** Customize the style of the drawn layer. Only for L.Path layers. Shapes can be excluded with a ignoreShapes array or merged with the current style with merge: true in  optionsModifier. */
+            setPathOptions(options: L.PathOptions, optionsModifier?: { ignoreShapes?: SUPPORTED_SHAPES[], merge?: boolean}): void;
 
             /** Returns all Geoman layers on the map as array. Pass true to get a L.FeatureGroup. */
             getGeomanLayers(asFeatureGroup?: boolean): L.FeatureGroup | L.Layer[];
@@ -964,6 +968,9 @@ declare module 'leaflet' {
 
             /** adds a button to remove layers (default:true) */
             removalMode?: boolean;
+
+            /** adds a button to rotate layers (default:true) */
+            rotateMode?: boolean;
 
             /** all buttons will be displayed as one block Customize Controls (default:false) */
             oneBlock?: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1448,6 +1448,12 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
+    "@types/geojson": {
+      "version": "7946.0.7",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
+      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -1459,6 +1465,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/leaflet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.7.0.tgz",
+      "integrity": "sha512-ltv5jR+VjKSMtoDkxH61Rsbo0zLU7iqyOXpVPkAX4F+79fg2eymC7t0msWsfNaEZO1FGTIQATCCCQe+ijWoicg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/node": {
       "version": "15.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@babel/core": "7.14.0",
     "@babel/preset-env": "7.14.1",
+    "@types/leaflet": "^1.7.0",
     "babel-loader": "8.2.2",
     "copy-webpack-plugin": "8.1.1",
     "css-loader": "5.2.4",


### PR DESCRIPTION
The pm property is now added to L.Path instead of L.Layer. Now we can have different pm handlers for LayerGroup and Layers.

Also added some missing fields, more information in #917

Fixes: #912, #917


@ryan-morris please take a look if there is a reason, why this should not work.

![leaflet_classes](https://user-images.githubusercontent.com/19800037/118833290-a0bef480-b8c1-11eb-9697-316b2e3156b7.PNG)
