### PR TITLE
LayerGroup: Some fixes with throttle and dragging

### DIFF
--- a/cypress/integration/layergroup.spec.js
+++ b/cypress/integration/layergroup.spec.js
@@ -350,4 +350,29 @@ describe('Edit LayerGroup', () => {
       expect(map.pm.getGeomanLayers().length).to.eq(6);
     })
   });
+
+  it('adds options to layers before throlle is fired', () => {
+    cy.toolbarButton('rectangle')
+      .click();
+    cy.get(mapSelector)
+      .click(200, 200)
+      .click(400, 350);
+
+    cy.toolbarButton('rectangle')
+      .click();
+    cy.get(mapSelector)
+      .click(350, 200)
+      .click(400, 400);
+
+    cy.window().then(({map, L}) => {
+      const fg = L.featureGroup().addTo(map);
+      var layers = map.pm.getGeomanDrawLayers();
+      layers.forEach((layer)=>{
+        fg.addLayer(layer);
+      });
+      fg.pm.setOptions({syncLayersOnDrag: true});
+
+      expect(layers[1].pm.options.syncLayersOnDrag).to.eq(true);
+    });
+  });
 });

--- a/src/js/Edit/L.PM.Edit.LayerGroup.js
+++ b/src/js/Edit/L.PM.Edit.LayerGroup.js
@@ -17,7 +17,7 @@ Edit.LayerGroup = L.Class.extend({
     // https://github.com/Leaflet/Leaflet/issues/4861
 
     const addThrottle = (e) => {
-      if (e.target._pmTempLayer) {
+      if (e.layer._pmTempLayer) {
         return;
       }
       this._layers = this.getLayers();
@@ -52,6 +52,9 @@ Edit.LayerGroup = L.Class.extend({
     this._layerGroup.on('layerremove', L.Util.throttle(removeThrottle, 100, this), this);
   },
   enable(options, _layerIds = []) {
+    if(_layerIds.length === 0) {
+      this._layers = this.getLayers();
+    }
     this._options = options;
     this._layers.forEach(layer => {
       if (layer instanceof L.LayerGroup) {
@@ -65,6 +68,9 @@ Edit.LayerGroup = L.Class.extend({
     });
   },
   disable(_layerIds = []) {
+    if(_layerIds.length === 0) {
+      this._layers = this.getLayers();
+    }
     this._layers.forEach(layer => {
       if (layer instanceof L.LayerGroup) {
         if (_layerIds.indexOf(layer._leaflet_id) === -1) {
@@ -77,6 +83,9 @@ Edit.LayerGroup = L.Class.extend({
     });
   },
   enabled(_layerIds = []) {
+    if(_layerIds.length === 0) {
+      this._layers = this.getLayers();
+    }
     const enabled = this._layers.find((layer) => {
       if (layer instanceof L.LayerGroup) {
         if (_layerIds.indexOf(layer._leaflet_id) === -1) {
@@ -90,6 +99,9 @@ Edit.LayerGroup = L.Class.extend({
     return !!enabled;
   },
   toggleEdit(options, _layerIds = []) {
+    if(_layerIds.length === 0) {
+      this._layers = this.getLayers();
+    }
     this._options = options;
     this._layers.forEach(layer => {
       if (layer instanceof L.LayerGroup) {
@@ -117,6 +129,7 @@ Edit.LayerGroup = L.Class.extend({
     }
   },
   dragging() {
+    this._layers = this.getLayers();
     if (this._layers) {
       const dragging = this._layers.find(layer => layer.pm.dragging());
       return !!dragging;
@@ -159,6 +172,9 @@ Edit.LayerGroup = L.Class.extend({
     return layers;
   },
   setOptions(options, _layerIds = []) {
+    if(_layerIds.length === 0) {
+      this._layers = this.getLayers();
+    }
     this._options = options;
     this._layers.forEach(layer => {
       if(layer.pm) {

--- a/src/js/Edit/L.PM.Edit.LayerGroup.js
+++ b/src/js/Edit/L.PM.Edit.LayerGroup.js
@@ -168,6 +168,12 @@ Edit.LayerGroup = L.Class.extend({
       layers = layers.filter(layer => !!layer.pm);
       // filter out everything that's leaflet-geoman specific temporary stuff
       layers = layers.filter(layer => !layer._pmTempLayer);
+      // filter out everything that ignore leaflet-geoman
+      layers = layers.filter(layer => (
+          (!L.PM.optIn && !layer.options.pmIgnore) || // if optIn is not set / true and pmIgnore is not set / true (default)
+          (L.PM.optIn && layer.options.pmIgnore === false) // if optIn is true and pmIgnore is false);
+        )
+      );
     }
     return layers;
   },

--- a/src/js/Edit/L.PM.Edit.LayerGroup.js
+++ b/src/js/Edit/L.PM.Edit.LayerGroup.js
@@ -137,7 +137,7 @@ Edit.LayerGroup = L.Class.extend({
     return false;
   },
   getOptions() {
-    return this._options;
+    return this.options;
   },
   _getMap(){
     return this._map || this._layers.find(l => !!l._map)?._map || null;
@@ -181,7 +181,7 @@ Edit.LayerGroup = L.Class.extend({
     if(_layerIds.length === 0) {
       this._layers = this.getLayers();
     }
-    this._options = options;
+    this.options = options;
     this._layers.forEach(layer => {
       if(layer.pm) {
         if (layer instanceof L.LayerGroup) {

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -313,6 +313,13 @@ const DragMixin = {
       if(L.Util.isArray(this.options.syncLayersOnDrag)){
         // layers
         layersToSync = this.options.syncLayersOnDrag;
+
+        this.options.syncLayersOnDrag.forEach((layer)=>{
+          if(layer instanceof L.LayerGroup){
+            layersToSync = layersToSync.concat(layer.pm.getLayers(true));
+          }
+        })
+
       }else if(this.options.syncLayersOnDrag === true){
         // LayerGroup
         if(this._parentLayerGroup){
@@ -330,7 +337,7 @@ const DragMixin = {
         layersToSync = layersToSync.filter(layer => !!layer.pm)
           .filter(layer => !!layer.pm.options.draggable);
         layersToSync.forEach((layer) => {
-          if (layer !== this._layer) {
+          if (layer !== this._layer && layer.pm[fnc]) {
             layer._snapped = false;
             layer.pm[fnc](e);
           }

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -326,8 +326,9 @@ const DragMixin = {
       }
 
       if(L.Util.isArray(layersToSync) && layersToSync.length > 0) {
-        // filter out layers that don't have leaflet-geoman
-        layersToSync = layersToSync.filter(layer => !!layer.pm);
+        // filter out layers that don't have leaflet-geoman and not allowed to drag
+        layersToSync = layersToSync.filter(layer => !!layer.pm)
+          .filter(layer => !!layer.pm.options.draggable);
         layersToSync.forEach((layer) => {
           if (layer !== this._layer) {
             layer._snapped = false;


### PR DESCRIPTION
Layer-add Throttle can be to slow if after adding layers directly a function is on the LayerGroup called.

```
// Draw a few layers
  var fg = L.featureGroup();

  function select(){
    var layers = map.pm.getGeomanDrawLayers();
    layers.forEach((layer)=>{
      fg.addLayer(layer);
    });
    fg.pm.setOptions({syncLayersOnDrag: true});
  }
```

----------------
Dragging:
- Added `draggable` option check to layergroup drag
- if a layergroup is passed to `syncLayersOnDrag: [layerGroup]` it gets all childs
- Add some checks like `pm` property