### PR TITLE
Fix: don't add Toolbar while creating new Draw Instance

### DIFF
--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -194,7 +194,7 @@ describe('Testing the Toolbar', () => {
       .parent('.leaflet-top.leaflet-left')
       .should('exist');
 
-    cy.window().then(({ map, L }) => {
+    cy.window().then(({ map }) => {
       let testresult = '';
 
       // Click button -> toggle disabled
@@ -291,6 +291,19 @@ describe('Testing the Toolbar', () => {
           });
       });
     });
+  });
+
+  it('Add new draw instance and keep Toolbar hidden', () => {
+    cy.window().then(({ map }) => {
+      map.pm.removeControls();
+    });
+    cy.get('.leaflet-pm-toolbar').should('not.exist');
+
+    cy.window().then(({ map }) => {
+      map.pm.Toolbar.copyDrawControl('Polygon', {name: 'PolygonCopy'});
+    });
+
+    cy.get('.leaflet-pm-toolbar').should('not.exist');
   });
 
   it('Custom Controls - Custom order', () => {

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -99,9 +99,9 @@ const Toolbar = L.Class.extend({
 
     this.applyIconStyle();
 
+    this.isVisible = true;
     // now show the specified buttons
     this._showHideButtons();
-    this.isVisible = true;
   },
   applyIconStyle() {
     const buttons = this.getButtons();
@@ -395,9 +395,17 @@ const Toolbar = L.Class.extend({
   },
 
   _showHideButtons() {
+
+    // if Toolbar is not visible, we don't need to update button positions
+    if(!this.isVisible){
+      return;
+    }
+
     // remove all buttons, that's because the Toolbar can be added again with
     // different options so it's basically a reset and add again
     this.removeControls();
+    // we need to set isVisible = true again, because removeControls() set it to false
+    this.isVisible = true;
 
     const buttons = this.getButtons();
     let ignoreBtns = [];
@@ -441,6 +449,7 @@ const Toolbar = L.Class.extend({
         buttons[btn].addTo(this.map);
       }
     }
+
   },
   _getBtnPosition(block) {
     return this.options.positions && this.options.positions[block]


### PR DESCRIPTION
When the Toolbar is not added to the map and then a new Draw Instance was created, the Toolbar was added to the map. -> We don't want this.