### PR TITLE
Fix dragging in Canvas mode

### DIFF
--- a/cypress/integration/imageoverlay.spec.js
+++ b/cypress/integration/imageoverlay.spec.js
@@ -33,4 +33,36 @@ describe('Opens Testing Environment', () => {
       expect(eventcalled).to.equal('pm:snap');
     });
   });
+
+  it('Drags ImageOverlay', () => {
+    let eventcalled = false;
+    let io;
+    cy.window().then(({ map, L }) => {
+      map.setView([18.74469, 72.1258], 10);
+      const icon =
+        'https://camo.githubusercontent.com/33fa9a94048274f81a806631ca881a55c2aa8f0a/68747470733a2f2f66696c652d6a787a796a67717775742e6e6f772e73682f';
+      io = L.imageOverlay(
+        icon,
+        [
+          [18.74469, 72.1258],
+          [18.94469, 72.3258],
+        ],
+        { interactive: true }
+      ).addTo(map);
+
+      io.pm._simulateMouseDownEvent = () => {
+        eventcalled = true;
+      };
+    });
+
+    cy.toolbarButton('drag').click();
+
+    cy.window().then(() => {
+      cy.get(io._image).trigger('mousedown');
+    });
+
+    cy.window().then(() => {
+      expect(eventcalled).to.equal(true);
+    });
+  });
 });

--- a/cypress/integration/rectangle.spec.js
+++ b/cypress/integration/rectangle.spec.js
@@ -568,4 +568,147 @@ describe('Draw Rectangle', () => {
       expect(maxLatUsed).to.eq(2);
     });
   });
+
+  it('Canvas drags syncLayers', () => {
+    let mapCanvas;
+
+    cy.window().then(({ L, map }) => {
+      map.remove();
+      const tiles = L.tileLayer(
+        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        {
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        }
+      );
+
+      // create the map
+      mapCanvas = L.map('map', {
+        preferCanvas: true,
+      })
+        .setView([51.505, -0.09], 13)
+        .addLayer(tiles);
+
+      // add leaflet-geoman toolbar
+      mapCanvas.pm.addControls();
+    });
+
+    cy.toolbarButton('rectangle').click();
+    cy.get(mapSelector).click(191, 216).click(608, 323);
+
+    cy.toolbarButton('rectangle').click();
+    cy.get(mapSelector).click(230, 230).click(350, 350);
+
+    cy.toolbarButton('drag').click();
+
+    cy.window().then(() => {
+      const layers = mapCanvas.pm.getGeomanDrawLayers();
+      let center1 = layers[0].getCenter();
+      let center2 = layers[1].getCenter();
+
+      const layer = layers[0];
+      // if this layer is dragged, all layers on the map should dragged too
+      layer.pm.options.syncLayersOnDrag = layers;
+
+      // Drag both layers
+      layer.pm._dragMixinOnMouseDown({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([290, 290]),
+      });
+      layer.pm._dragMixinOnMouseMove({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([500, 320]),
+      });
+      layer.pm._dragMixinOnMouseUp({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([320, 320]),
+      });
+
+      expect(center1.equals(layers[0].getCenter())).to.eq(false);
+      expect(center2.equals(layers[1].getCenter())).to.eq(false);
+
+      center1 = layers[0].getCenter();
+      center2 = layers[1].getCenter();
+
+      const layer2 = layers[1];
+      // Drag only layer2
+      layer2.pm._dragMixinOnMouseDown({
+        originalEvent: { button: 0 },
+        target: layer2,
+        latlng: mapCanvas.containerPointToLatLng([290, 290]),
+      });
+      layer2.pm._dragMixinOnMouseMove({
+        originalEvent: { button: 0 },
+        target: layer2,
+        latlng: mapCanvas.containerPointToLatLng([500, 320]),
+      });
+      layer2.pm._dragMixinOnMouseUp({
+        originalEvent: { button: 0 },
+        target: layer2,
+        latlng: mapCanvas.containerPointToLatLng([320, 320]),
+      });
+
+      expect(center1.equals(layers[0].getCenter())).to.eq(true);
+      expect(center2.equals(layers[1].getCenter())).to.eq(false);
+    });
+  });
+
+  it('Canvas drag a simple layer', () => {
+    let mapCanvas;
+
+    cy.window().then(({ L, map }) => {
+      map.remove();
+      const tiles = L.tileLayer(
+        'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        {
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        }
+      );
+
+      // create the map
+      mapCanvas = L.map('map', {
+        preferCanvas: true,
+      })
+        .setView([51.505, -0.09], 13)
+        .addLayer(tiles);
+
+      // add leaflet-geoman toolbar
+      mapCanvas.pm.addControls();
+    });
+
+    cy.toolbarButton('rectangle').click();
+    cy.get(mapSelector).click(191, 216).click(608, 323);
+
+    cy.toolbarButton('drag').click();
+
+    cy.window().then(() => {
+      const layers = mapCanvas.pm.getGeomanDrawLayers();
+      const center1 = layers[0].getCenter();
+
+      const layer = layers[0];
+
+      // Drag both layers
+      layer.pm._dragMixinOnMouseDown({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([290, 290]),
+      });
+      layer.pm._dragMixinOnMouseMove({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([500, 320]),
+      });
+      layer.pm._dragMixinOnMouseUp({
+        originalEvent: { button: 0 },
+        target: layer,
+        latlng: mapCanvas.containerPointToLatLng([320, 320]),
+      });
+
+      expect(center1.equals(layers[0].getCenter())).to.eq(false);
+    });
+  });
 });

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -188,6 +188,92 @@ const Map = L.Class.extend({
   _isCRSSimple() {
     return this.map.options.crs === L.CRS.Simple;
   },
+  // in Canvas mode we need to convert touch- and pointerevents (IE) to mouseevents, because Leaflet don't support them.
+  _touchEventCounter: 0,
+  _addTouchEvents(elm) {
+    if (this._touchEventCounter === 0) {
+      L.DomEvent.on(elm, 'touchmove', this._canvasTouchMove, this);
+      L.DomEvent.on(
+        elm,
+        'touchstart touchend touchcancel',
+        this._canvasTouchClick,
+        this
+      );
+    }
+    this._touchEventCounter += 1;
+  },
+  _removeTouchEvents(elm) {
+    if (this._touchEventCounter === 1) {
+      L.DomEvent.off(elm, 'touchmove', this._canvasTouchMove, this);
+      L.DomEvent.off(
+        elm,
+        'touchstart touchend touchcancel',
+        this._canvasTouchClick,
+        this
+      );
+    }
+    this._touchEventCounter =
+      this._touchEventCounter <= 1 ? 0 : this._touchEventCounter - 1;
+  },
+  _canvasTouchMove(e) {
+    this.map._renderer._onMouseMove(this._createMouseEvent('mousemove', e));
+  },
+  _canvasTouchClick(e) {
+    let type = '';
+    if (e.type === 'touchstart' || e.type === 'pointerdown') {
+      type = 'mousedown';
+    } else if (e.type === 'touchend' || e.type === 'pointerup') {
+      type = 'mouseup';
+    } else if (e.type === 'touchcancel' || e.type === 'pointercancel') {
+      type = 'mouseup';
+    }
+    if (!type) {
+      return;
+    }
+    this.map._renderer._onClick(this._createMouseEvent(type, e));
+  },
+  _createMouseEvent(type, e) {
+    let mouseEvent;
+    const touchEvt = e.touches[0] || e.changedTouches[0];
+    try {
+      mouseEvent = new MouseEvent(type, {
+        bubbles: e.bubbles,
+        cancelable: e.cancelable,
+        view: e.view,
+        detail: touchEvt.detail,
+        screenX: touchEvt.screenX,
+        screenY: touchEvt.screenY,
+        clientX: touchEvt.clientX,
+        clientY: touchEvt.clientY,
+        ctrlKey: e.ctrlKey,
+        altKey: e.altKey,
+        shiftKey: e.shiftKey,
+        metaKey: e.metaKey,
+        button: e.button,
+        relatedTarget: e.relatedTarget,
+      });
+    } catch (ex) {
+      mouseEvent = document.createEvent('MouseEvents');
+      mouseEvent.initMouseEvent(
+        type,
+        e.bubbles,
+        e.cancelable,
+        e.view,
+        touchEvt.detail,
+        touchEvt.screenX,
+        touchEvt.screenY,
+        touchEvt.clientX,
+        touchEvt.clientY,
+        e.ctrlKey,
+        e.altKey,
+        e.shiftKey,
+        e.metaKey,
+        e.button,
+        e.relatedTarget
+      );
+    }
+    return mouseEvent;
+  },
 });
 
 export default Map;

--- a/src/js/L.PM.js
+++ b/src/js/L.PM.js
@@ -214,5 +214,34 @@ L.PM = L.PM || {
   },
 };
 
+if (L.version === '1.7.1') {
+  // Canvas Mode: After dragging the map the target layer can't be dragged anymore until it is clicked
+  // https://github.com/Leaflet/Leaflet/issues/7775 a fix is already merged for the Leaflet 1.8.0 version
+  L.Canvas.include({
+    _onClick: function (e) {
+      var point = this._map.mouseEventToLayerPoint(e),
+        layer,
+        clickedLayer;
+
+      for (var order = this._drawFirst; order; order = order.next) {
+        layer = order.layer;
+        if (layer.options.interactive && layer._containsPoint(point)) {
+          // changing e.type !== 'preclick' to e.type === 'preclick' fix the issue
+          if (
+            !(e.type === 'click' || e.type === 'preclick') ||
+            !this._map._draggableMoved(layer)
+          ) {
+            clickedLayer = layer;
+          }
+        }
+      }
+      if (clickedLayer) {
+        L.DomEvent.fakeStop(e);
+        this._fireEvent([clickedLayer], e);
+      }
+    },
+  });
+}
+
 // initialize leaflet-geoman
 L.PM.initialize();

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -45,20 +45,28 @@ const DragMixin = {
     // (if the mouse up event happens outside the container, then the map can become undraggable)
     this._safeToCacheDragState = true;
 
-    const container =
-      this._layer instanceof L.Marker ? this._layer._icon : this._layer._path;
+    const container = this._getDOMElem();
 
     // check if DOM element exists
     if (container) {
       // add mousedown event to trigger drag
-      // We can't just use layer.on('mousedown') because on touch devices the event is not fired if user presses on the layer and then drag it.
-      // With checking on touchstart and mousedown on the DOM element we can listen on the needed events
-      L.DomEvent.on(
-        container,
-        'touchstart mousedown',
-        this._simulateMouseDownEvent,
-        this
-      );
+      if (this._layer._map?.options.preferCanvas && this._layer._renderer) {
+        this._layer.on(
+          'touchstart mousedown',
+          this._dragMixinOnMouseDown,
+          this
+        );
+        this._map.pm._addTouchEvents(container);
+      } else {
+        // We can't just use layer.on('mousedown') because on touch devices the event is not fired if user presses on the layer and then drag it.
+        // With checking on touchstart and mousedown on the DOM element we can listen on the needed events
+        L.DomEvent.on(
+          container,
+          'touchstart mousedown',
+          this._simulateMouseDownEvent,
+          this
+        );
+      }
     }
 
     // TODO: should we add Events "enabledrag" / "disabledrag"?
@@ -81,17 +89,25 @@ const DragMixin = {
       this._layer.dragging.disable();
     }
 
-    const container =
-      this._layer instanceof L.Marker ? this._layer._icon : this._layer._path;
+    const container = this._getDOMElem();
     // check if DOM element exists
     if (container) {
-      // disable mousedown event
-      L.DomEvent.off(
-        container,
-        'touchstart mousedown',
-        this._simulateMouseDownEvent,
-        this
-      );
+      if (this._layer._map?.options.preferCanvas && this._layer._renderer) {
+        this._layer.off(
+          'touchstart mousedown',
+          this._dragMixinOnMouseDown,
+          this
+        );
+        this._map.pm._removeTouchEvents(container);
+      } else {
+        // disable mousedown event
+        L.DomEvent.off(
+          container,
+          'touchstart mousedown',
+          this._simulateMouseDownEvent,
+          this
+        );
+      }
     }
   },
   // TODO: make this private in the next major release
@@ -108,8 +124,9 @@ const DragMixin = {
       originalEvent: e,
       target: this._layer,
     };
+    var first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
-    evt.containerPoint = this._map.mouseEventToContainerPoint(e);
+    evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
 
     this._dragMixinOnMouseDown(evt);
@@ -120,8 +137,9 @@ const DragMixin = {
       originalEvent: e,
       target: this._layer,
     };
+    var first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
-    evt.containerPoint = this._map.mouseEventToContainerPoint(e);
+    evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
 
     this._dragMixinOnMouseMove(evt);
@@ -132,10 +150,11 @@ const DragMixin = {
       originalEvent: e,
       target: this._layer,
     };
-    // we expect in the function to get the clicked latlng / point
-    evt.containerPoint = this._map.mouseEventToContainerPoint(e);
-    evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
-
+    if (e.type.indexOf('touch') === -1) {
+      // we expect in the function to get the clicked latlng / point
+      evt.containerPoint = this._map.mouseEventToContainerPoint(e);
+      evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
+    }
     this._dragMixinOnMouseUp(evt);
     return false;
   },


### PR DESCRIPTION
After fixing dragging for touch devices in the Release 2.11.0, dragging was not supported anymore for Canvas mode.

fix #1023, fix #1027