### PR TITLE
Fix dragging with Canvas renderer

### DIFF
--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -6,6 +6,7 @@ import GlobalRemovalMode from './Mixins/Modes/Mode.Removal';
 import GlobalRotateMode from './Mixins/Modes/Mode.Rotate';
 import EventMixin from './Mixins/Events';
 import KeyboardMixins from './Mixins/Keyboard';
+import { getRenderer } from './helpers';
 
 const Map = L.Class.extend({
   includes: [
@@ -217,7 +218,7 @@ const Map = L.Class.extend({
       this._touchEventCounter <= 1 ? 0 : this._touchEventCounter - 1;
   },
   _canvasTouchMove(e) {
-    this.map._renderer._onMouseMove(this._createMouseEvent('mousemove', e));
+    getRenderer(this.map)._onMouseMove(this._createMouseEvent('mousemove', e));
   },
   _canvasTouchClick(e) {
     let type = '';
@@ -231,7 +232,7 @@ const Map = L.Class.extend({
     if (!type) {
       return;
     }
-    this.map._renderer._onClick(this._createMouseEvent(type, e));
+    getRenderer(this.map)._onClick(this._createMouseEvent(type, e));
   },
   _createMouseEvent(type, e) {
     let mouseEvent;

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -1,3 +1,5 @@
+import { getRenderer } from '../helpers';
+
 const DragMixin = {
   enableLayerDrag() {
     // layer is not allowed to dragged or is not on the map
@@ -32,7 +34,7 @@ const DragMixin = {
     this._tempDragCoord = null;
 
     // add CSS class
-    if (this._layer._map?.options.preferCanvas) {
+    if (getRenderer(this._layer) instanceof L.Canvas) {
       this._layer.on('mouseout', this.removeDraggingClass, this);
       this._layer.on('mouseover', this.addDraggingClass, this);
     } else {
@@ -50,7 +52,7 @@ const DragMixin = {
     // check if DOM element exists
     if (container) {
       // add mousedown event to trigger drag
-      if (this._layer._map?.options.preferCanvas && this._layer._renderer) {
+      if (getRenderer(this._layer) instanceof L.Canvas) {
         this._layer.on(
           'touchstart mousedown',
           this._dragMixinOnMouseDown,
@@ -75,7 +77,7 @@ const DragMixin = {
     this._layerDragEnabled = false;
 
     // remove CSS class
-    if (this._layer._map?.options.preferCanvas) {
+    if (getRenderer(this._layer) instanceof L.Canvas) {
       this._layer.off('mouseout', this.removeDraggingClass, this);
       this._layer.off('mouseover', this.addDraggingClass, this);
     } else {
@@ -98,7 +100,7 @@ const DragMixin = {
     const container = this._getDOMElem();
     // check if DOM element exists
     if (container) {
-      if (this._layer._map?.options.preferCanvas && this._layer._renderer) {
+      if (getRenderer(this._layer) instanceof L.Canvas) {
         this._layer.off(
           'touchstart mousedown',
           this._dragMixinOnMouseDown,

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -264,3 +264,12 @@ export function fixLatOffset(latlng, map) {
   }
   return latlng;
 }
+
+export function getRenderer(layer) {
+  return (
+    layer.options.renderer ||
+    layer._map._getPaneRenderer(layer.options.pane) ||
+    layer._map.options.renderer ||
+    layer._map._renderer
+  );
+}


### PR DESCRIPTION
Fix: #1069 

If a canvas renderer was used on the map, dragging was not working correct.
- Always `drag-cursor` was enabled
- all layers in the canvas were dragged
- With `preferCanvas` an error in the console was throwed

```
const map = L.map('map', {
  renderer: L.canvas({
    padding: 0.5
  })
})
```
https://jsfiddle.net/falkedesign/vka3yh19/