### PR TITLE
Remove Node Engine. Fixes #1082 (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoman-io/leaflet-geoman-free",
   "version": "2.11.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoman-io/leaflet-geoman-free",
-      "version": "2.11.2",
+      "version": "2.11.4",
       "license": "MIT",
       "dependencies": {
         "@turf/boolean-contains": "^6.5.0",
@@ -39,9 +39,6 @@
         "url-loader": "4.1.1",
         "webpack": "5.36.2",
         "webpack-cli": "4.7.0"
-      },
-      "engines": {
-        "node": ">=16.13 <17"
       },
       "peerDependencies": {
         "leaflet": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   "files": [
     "dist"
   ],
-  "engines": {
-    "node": ">=16.13 <17"
-  },
   "main": "dist/leaflet-geoman.min.js",
   "types": "dist/leaflet-geoman.d.ts",
   "dependencies": {


### PR DESCRIPTION
Enforcing a node version broke user implementations instead of its intended use: enforcing node version 16 among contributors. So, we are reverting this for now. Fixes #1082 