### PR TITLE
Improvement disable control button when change state we do not redraw panel

### DIFF
--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -413,9 +413,6 @@ describe('Testing the Toolbar', () => {
   });
   it('Disable active button', () => {
     let eventFired = '';
-
-    cy.toolbarButton('polygon').click();
-
     cy.window().then(({ map }) => {
       map.on('pm:buttonclick', ({ btnName }) => {
         eventFired = btnName;

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -408,7 +408,31 @@ describe('Testing the Toolbar', () => {
     cy.toolbarButton('polygon').click();
 
     cy.window().then(() => {
-      expect(eventFired).to.not.equal('drawPolygon');
+      expect(eventFired).to.equal('drawPolygon');
+    });
+  });
+  it('Disable active button', () => {
+    let eventFired = '';
+
+    cy.toolbarButton('polygon').click();
+
+    cy.window().then(({ map }) => {
+      map.on('pm:buttonclick', ({ btnName }) => {
+        eventFired = btnName;
+      });
+    });
+
+    cy.toolbarButton('polygon').click();
+
+    cy.window().then(({ map }) => {
+      map.pm.Toolbar.setButtonDisabled('drawPolygon', true);
+    });
+
+    cy.window().then(() => {
+      expect(eventFired).to.equal('drawPolygon');
+      cy.toolbarButton('polygon')
+        .closest('.button-container')
+        .should('have.not.class', 'active');
     });
   });
 });

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -436,12 +436,14 @@ describe('Testing the Toolbar', () => {
         .closest('.button-container')
         .should('have.class', 'active')
         .then(() => {
+          expect(eventFired).to.equal('drawPolygon');
+          eventFired = '';
           map.pm.Toolbar.setButtonDisabled('drawPolygon', true);
         });
     });
 
     cy.window().then(() => {
-      expect(eventFired).to.equal('drawPolygon');
+      expect(eventFired).to.not.equal('drawPolygon');
       cy.toolbarButton('polygon')
         .closest('.button-container')
         .should('have.not.class', 'active');

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -417,12 +417,14 @@ describe('Testing the Toolbar', () => {
       map.on('pm:buttonclick', ({ btnName }) => {
         eventFired = btnName;
       });
-    });
 
-    cy.toolbarButton('polygon').click();
-
-    cy.window().then(({ map }) => {
-      map.pm.Toolbar.setButtonDisabled('drawPolygon', true);
+      cy.toolbarButton('polygon')
+        .click()
+        .closest('.button-container')
+        .should('have.class', 'active')
+        .then(() => {
+          map.pm.Toolbar.setButtonDisabled('drawPolygon', true);
+        });
     });
 
     cy.window().then(() => {

--- a/src/css/controls.css
+++ b/src/css/controls.css
@@ -183,6 +183,6 @@
   background-color: #f4f4f4;
 }
 
-.control-icon.pm-disabled {
+.leaflet-buttons-control-button.pm-disabled > .control-icon {
   filter: opacity(0.6);
 }

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -211,20 +211,7 @@ const PMButton = L.Control.extend({
     if (!button.disabled) {
       // before the actual click, trigger a click on currently toggled buttons to
       // untoggle them and their functionality
-      L.DomEvent.addListener(newButton, 'click', () => {
-        if (this._button.disableOtherButtons) {
-          this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
-        }
-        let btnName = '';
-        const { buttons } = this._map.pm.Toolbar;
-        for (const btn in buttons) {
-          if (buttons[btn]._button === button) {
-            btnName = btn;
-            break;
-          }
-        }
-        this._fireButtonClick(btnName, button);
-      });
+      L.DomEvent.addListener(newButton, 'click', this._onBtnClick, this);
       L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
     }
 
@@ -250,6 +237,21 @@ const PMButton = L.Control.extend({
     }
   },
 
+  _onBtnClick() {
+    if (this._button.disableOtherButtons) {
+      this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
+    }
+    let btnName = '';
+    const { buttons } = this._map.pm.Toolbar;
+    for (const btn in buttons) {
+      if (buttons[btn]._button === this._button) {
+        btnName = btn;
+        break;
+      }
+    }
+    this._fireButtonClick(btnName, this._button);
+  },
+
   _clicked() {
     if (this._button.doToggle) {
       this.toggle();
@@ -263,6 +265,8 @@ const PMButton = L.Control.extend({
     if (this._button.disabled) {
       L.DomUtil.addClass(button, className);
       button.setAttribute('aria-disabled', 'true');
+      L.DomEvent.off(button, 'click', this._triggerClick, this);
+      L.DomEvent.off(button, 'click', this._onBtnClick, this);
     } else {
       L.DomUtil.removeClass(button, className);
       button.setAttribute('aria-disabled', 'false');

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -64,10 +64,22 @@ const PMButton = L.Control.extend({
   onCreate() {
     this.toggle(false);
   },
+  disable() {
+    this.toggle(false); // is needed to prevent active button disabled
+    this._button.disabled = true;
+    this._updateDisabled();
+  },
+  enable() {
+    this._button.disabled = false;
+    this._updateDisabled();
+  },
   _triggerClick(e) {
     if (e) {
       // is needed to prevent scrolling when clicking on a-element with href="a"
       e.preventDefault();
+    }
+    if (this._button.disabled) {
+      return;
     }
     // TODO is this a big change when we change from e to a object with the event and the button? Now it's the second argument
     this._button.onClick(e, { button: this, event: e });
@@ -151,25 +163,23 @@ const PMButton = L.Control.extend({
 
       actionNode.innerHTML = action.text;
 
-      if (!button.disabled) {
-        if (action.onClick) {
-          const actionClick = (e) => {
-            // is needed to prevent scrolling when clicking on a-element with href="a"
-            e.preventDefault();
-            let btnName = '';
-            const { buttons } = this._map.pm.Toolbar;
-            for (const btn in buttons) {
-              if (buttons[btn]._button === button) {
-                btnName = btn;
-                break;
-              }
+      if (action.onClick) {
+        const actionClick = (e) => {
+          // is needed to prevent scrolling when clicking on a-element with href="a"
+          e.preventDefault();
+          let btnName = '';
+          const { buttons } = this._map.pm.Toolbar;
+          for (const btn in buttons) {
+            if (buttons[btn]._button === button) {
+              btnName = btn;
+              break;
             }
-            this._fireActionClick(action, btnName, button);
-          };
+          }
+          this._fireActionClick(action, btnName, button);
+        };
 
-          L.DomEvent.addListener(actionNode, 'click', actionClick, this);
-          L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
-        }
+        L.DomEvent.addListener(actionNode, 'click', actionClick, this);
+        L.DomEvent.addListener(actionNode, 'click', action.onClick, this);
       }
       L.DomEvent.disableClickPropagation(actionNode);
     });
@@ -190,29 +200,27 @@ const PMButton = L.Control.extend({
     if (button.className) {
       L.DomUtil.addClass(image, button.className);
     }
-    if (!button.disabled) {
-      // before the actual click, trigger a click on currently toggled buttons to
-      // untoggle them and their functionality
-      L.DomEvent.addListener(newButton, 'click', () => {
-        if (this._button.disableOtherButtons) {
-          this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
+    // before the actual click, trigger a click on currently toggled buttons to
+    // untoggle them and their functionality
+    L.DomEvent.addListener(newButton, 'click', () => {
+      if (this._button.disableOtherButtons) {
+        this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
+      }
+      let btnName = '';
+      const { buttons } = this._map.pm.Toolbar;
+      for (const btn in buttons) {
+        if (buttons[btn]._button === button) {
+          btnName = btn;
+          break;
         }
-        let btnName = '';
-        const { buttons } = this._map.pm.Toolbar;
-        for (const btn in buttons) {
-          if (buttons[btn]._button === button) {
-            btnName = btn;
-            break;
-          }
-        }
-        this._fireButtonClick(btnName, button);
-      });
-      L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
-    }
+      }
+      this._fireButtonClick(btnName, button);
+    });
+    L.DomEvent.addListener(newButton, 'click', this._triggerClick, this);
 
     if (button.disabled) {
       L.DomUtil.addClass(newButton, 'pm-disabled');
-      L.DomUtil.addClass(image, 'pm-disabled');
+      newButton.setAttribute('aria-disabled', 'true');
     }
 
     L.DomEvent.disableClickPropagation(newButton);
@@ -236,6 +244,19 @@ const PMButton = L.Control.extend({
   _clicked() {
     if (this._button.doToggle) {
       this.toggle();
+    }
+  },
+
+  _updateDisabled() {
+    const className = 'pm-disabled';
+    const button = this.buttonsDomNode.children[0];
+
+    if (this._button.disabled) {
+      L.DomUtil.addClass(button, className);
+      button.setAttribute('aria-disabled', 'true');
+    } else {
+      L.DomUtil.removeClass(button, className);
+      button.setAttribute('aria-disabled', 'false');
     }
   },
 });

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -638,8 +638,11 @@ const Toolbar = L.Class.extend({
   },
   setButtonDisabled(name, state) {
     const btnName = this._btnNameMapping(name);
-    this.buttons[btnName]._button.disabled = !!state;
-    this._showHideButtons();
+    if (state) {
+      this.buttons[btnName].disable();
+    } else {
+      this.buttons[btnName].enable();
+    }
   },
   _shapeMapping() {
     return {


### PR DESCRIPTION
When studying the code, it was found that the optimal movement, which causes a complete redrawing of the control panel, when changes disable state.

This PR makes the following changes: 

- When we change disable state, we change CSS class and internal state
- When you lock a button, we forcibly render it inactive
- Changed CSS styles to remove class duplication for different DOM element