### PR TITLE
Add new events `pm:dragenable`, `pm:dragdisable`, `pm:change`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,13 +327,14 @@ map.on('pm:drawstart', ({ workingLayer }) => {
 
 Here's a list of layer events you can listen to:
 
-| Event           | Params | Description                                                                                                           | Output                                                                                                  |
-| :-------------- | :----- | :-------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
-| pm:vertexadded  | `e`    | Called when a new vertex is added. Payload includes the new vertex, it's marker, index, working layer and shape type. | `shape`, `workingLayer`, `marker`, `latlng`                                                             |
-| pm:snapdrag     | `e`    | Fired during a marker move/drag. Payload includes info about involved layers and snapping calculation.                | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
-| pm:snap         | `e`    | Fired when a vertex is snapped. Payload is the same as in `snapdrag`.                                                 | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
-| pm:unsnap       | `e`    | Fired when a vertex is unsnapped. Payload is the same as in `snapdrag`.                                               | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
-| pm:centerplaced | `e`    | Called when the center of a circle is placed/moved.                                                                   | `shape`, `workingLayer`, `latlng`                                                                       |
+| Event             | Params | Description                                                                                                           | Output                                                                                                  |
+| :---------------- | :----- | :-------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| pm:vertexadded    | `e`    | Called when a new vertex is added. Payload includes the new vertex, it's marker, index, working layer and shape type. | `shape`, `workingLayer`, `marker`, `latlng`                                                             |
+| pm:snapdrag       | `e`    | Fired during a marker move/drag. Payload includes info about involved layers and snapping calculation.                | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
+| pm:snap           | `e`    | Fired when a vertex is snapped. Payload is the same as in `snapdrag`.                                                 | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
+| pm:unsnap         | `e`    | Fired when a vertex is unsnapped. Payload is the same as in `snapdrag`.                                               | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
+| pm:centerplaced   | `e`    | Called when the center of a circle is placed/moved.                                                                   | `shape`, `workingLayer`, `latlng`                                                                       |
+| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed.                                                                 | `layer`, `latlng`, `shape`                                                                              |
 
 For making the snapping to other layers selective, you can add the "snapIgnore" option to your layers to disable the snapping to them during drawing.
 
@@ -443,7 +444,7 @@ The following events are available on a layer instance:
 | pm:unsnap          | `e`    | Fired when a vertex-marker is unsnapped from a vertex. Also fired on the marker itself.                | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:intersect       | `e`    | When `allowSelfIntersection: false`, this event is fired as soon as a self-intersection is detected.   | `layer`, `intersection`, `shape`                                                                        |
 | pm:centerplaced    | `e`    | Fired when the center of a circle is moved.                                                            | `layer`, `latlng`, `shape`                                                                              |
-
+| pm:positionchange  | `e`    | Fired when position / coordinates of a layer changed.                                                  | `layer`, `latlng`, `shape`                                                                              |
 The following events are available on a map instance:
 
 | Event                    | Params | Description                      | Output           |
@@ -493,11 +494,14 @@ The following methods are available on `map.pm`:
 
 The following events are available on a layer instance:
 
-| Event        | Params | Description                              | Output                                                                    |
-| :----------- | :----- | :--------------------------------------- | :------------------------------------------------------------------------ |
-| pm:dragstart | `e`    | Fired when a layer starts being dragged. | `layer`, `shape`                                                          |
-| pm:drag      | `e`    | Fired when a layer is dragged.           | `layer`, `containerPoint`,`latlng`, `layerPoint`,`originalEvent`, `shape` |
-| pm:dragend   | `e`    | Fired when a layer stops being dragged.  | `layer`, `shape`                                                          |
+| Event             | Params | Description                                               | Output                                                                    |
+| :---------------- | :----- | :-------------------------------------------------------- | :------------------------------------------------------------------------ |
+| pm:dragstart      | `e`    | Fired when a layer starts being dragged.                  | `layer`, `shape`                                                          |
+| pm:drag           | `e`    | Fired when a layer is dragged.                            | `layer`, `containerPoint`,`latlng`, `layerPoint`,`originalEvent`, `shape` |
+| pm:dragend        | `e`    | Fired when a layer stops being dragged.                   | `layer`, `shape`                                                          |
+| pm:dragenable     | `e`    | Fired when Drag Mode on a layer is enabled.               | `layer`, `shape`                                                          |
+| pm:dragdisable    | `e`    | Fired when Drag Mode on a layer is disabled.              | `layer`, `shape`                                                          |
+| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed.     | `layer`, `latlng`, `shape`                                                |
 
 The following events are available on a map instance:
 
@@ -629,21 +633,22 @@ The following methods are available for layers under `layer.pm`:
 
 The following events are available on a layer instance:
 
-| Event            | Params | Description                                  | Output                                                                               |
-| :--------------- | :----- | :------------------------------------------- | :----------------------------------------------------------------------------------- |
-| pm:rotateenable  | `e`    | Fired when rotation is enabled for a layer.  | `layer`, `helpLayer`                                                                 |
-| pm:rotatedisable | `e`    | Fired when rotation is disabled for a layer. | `layer`                                                                              |
-| pm:rotatestart   | `e`    | Fired when rotation starts on a layer.       | `layer`, `helpLayer`, `startAngle`, `originLatLngs`                                  |
-| pm:rotate        | `e`    | Fired when a layer is rotated.               | `layer`, `helpLayer`, `startAngle`, `angle`, `angleDiff`, `oldLatLngs`, `newLatLngs` |
-| pm:rotateend     | `e`    | Fired when rotation ends on a layer.         | `layer`, `helpLayer`, `startAngle`, `angle`, `originLatLngs`, `newLatLngs`           |
+| Event             | Params | Description                                           | Output                                                                               |
+| :---------------- | :----- | :---------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| pm:rotateenable   | `e`    | Fired when rotation is enabled for a layer.           | `layer`, `helpLayer`, `shape`                                                        |
+| pm:rotatedisable  | `e`    | Fired when rotation is disabled for a layer.          | `layer`, `shape`                                                                     |
+| pm:rotatestart    | `e`    | Fired when rotation starts on a layer.                | `layer`, `helpLayer`, `startAngle`, `originLatLngs`                                  |
+| pm:rotate         | `e`    | Fired when a layer is rotated.                        | `layer`, `helpLayer`, `startAngle`, `angle`, `angleDiff`, `oldLatLngs`, `newLatLngs` |
+| pm:rotateend      | `e`    | Fired when rotation ends on a layer.                  | `layer`, `helpLayer`, `startAngle`, `angle`, `originLatLngs`, `newLatLngs`           |
+| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed. | `layer`, `latlng`, `shape`                                                           |
 
 The following events are available on a map instance:
 
 | Event                      | Params | Description                                  | Output                                                                               |
 | :------------------------- | :----- | :------------------------------------------- | :----------------------------------------------------------------------------------- |
 | pm:globalrotatemodetoggled | `e`    | Fired when Rotate Mode is toggled.           | `enabled`, `map`                                                                     |
-| pm:rotateenable            | `e`    | Fired when rotation is enabled for a layer.  | `layer`, `helpLayer`                                                                 |
-| pm:rotatedisable           | `e`    | Fired when rotation is disabled for a layer. | `layer`                                                                              |
+| pm:rotateenable            | `e`    | Fired when rotation is enabled for a layer.  | `layer`, `helpLayer`, `shape`                                                        |
+| pm:rotatedisable           | `e`    | Fired when rotation is disabled for a layer. | `layer`, `shape`                                                                     |
 | pm:rotatestart             | `e`    | Fired when rotation starts on a layer.       | `layer`, `helpLayer`, `startAngle`, `originLatLngs`                                  |
 | pm:rotate                  | `e`    | Fired when a layer is rotated.               | `layer`, `helpLayer`, `startAngle`, `angle`, `angleDiff`, `oldLatLngs`, `newLatLngs` |
 | pm:rotateend               | `e`    | Fired when rotation ends on a layer.         | `layer`, `helpLayer`, `startAngle`, `angle`, `originLatLngs`, `newLatLngs`           |

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Here's a list of layer events you can listen to:
 | pm:snap           | `e`    | Fired when a vertex is snapped. Payload is the same as in `snapdrag`.                                                 | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:unsnap         | `e`    | Fired when a vertex is unsnapped. Payload is the same as in `snapdrag`.                                               | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:centerplaced   | `e`    | Called when the center of a circle is placed/moved.                                                                   | `shape`, `workingLayer`, `latlng`                                                                       |
-| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed.                                                                 | `layer`, `latlng`, `shape`                                                                              |
+| pm:change         | `e`    | Fired coordinates of the layer changed.                                                                               | `layer`, `latlngs`, `shape`                                                                             |
 
 For making the snapping to other layers selective, you can add the "snapIgnore" option to your layers to disable the snapping to them during drawing.
 
@@ -444,7 +444,7 @@ The following events are available on a layer instance:
 | pm:unsnap          | `e`    | Fired when a vertex-marker is unsnapped from a vertex. Also fired on the marker itself.                | `shape`, `distance`, `layer` = `workingLayer`, `marker`, `layerInteractedWith`, `segment`, `snapLatLng` |
 | pm:intersect       | `e`    | When `allowSelfIntersection: false`, this event is fired as soon as a self-intersection is detected.   | `layer`, `intersection`, `shape`                                                                        |
 | pm:centerplaced    | `e`    | Fired when the center of a circle is moved.                                                            | `layer`, `latlng`, `shape`                                                                              |
-| pm:positionchange  | `e`    | Fired when position / coordinates of a layer changed.                                                  | `layer`, `latlng`, `shape`                                                                              |
+| pm:change          | `e`    | Fired coordinates of the layer changed.                                                                | `layer`, `latlngs`, `shape`                                                                             |
 The following events are available on a map instance:
 
 | Event                    | Params | Description                      | Output           |
@@ -501,7 +501,7 @@ The following events are available on a layer instance:
 | pm:dragend        | `e`    | Fired when a layer stops being dragged.                   | `layer`, `shape`                                                          |
 | pm:dragenable     | `e`    | Fired when Drag Mode on a layer is enabled.               | `layer`, `shape`                                                          |
 | pm:dragdisable    | `e`    | Fired when Drag Mode on a layer is disabled.              | `layer`, `shape`                                                          |
-| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed.     | `layer`, `latlng`, `shape`                                                |
+| pm:change         | `e`    | Fired coordinates of the layer changed.                   | `layer`, `latlngs`, `shape`                                                |
 
 The following events are available on a map instance:
 
@@ -640,7 +640,7 @@ The following events are available on a layer instance:
 | pm:rotatestart    | `e`    | Fired when rotation starts on a layer.                | `layer`, `helpLayer`, `startAngle`, `originLatLngs`                                  |
 | pm:rotate         | `e`    | Fired when a layer is rotated.                        | `layer`, `helpLayer`, `startAngle`, `angle`, `angleDiff`, `oldLatLngs`, `newLatLngs` |
 | pm:rotateend      | `e`    | Fired when rotation ends on a layer.                  | `layer`, `helpLayer`, `startAngle`, `angle`, `originLatLngs`, `newLatLngs`           |
-| pm:positionchange | `e`    | Fired when position / coordinates of a layer changed. | `layer`, `latlng`, `shape`                                                           |
+| pm:change         | `e`    | Fired coordinates of the layer changed.               | `layer`, `latlngs`, `shape`                                                           |
 
 The following events are available on a map instance:
 

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -281,10 +281,10 @@ declare module 'leaflet' {
     once(type: 'pm:intersect', fn: PM.IntersectEventHandler): this;
     off(type: 'pm:intersect', fn?: PM.IntersectEventHandler): this;
 
-    /** Fired when position / coordinates of a layer changed. */
-    on(type: 'pm:positionchange', fn: PM.PositionChangeEventHandler): this;
-    once(type: 'pm:positionchange', fn: PM.PositionChangeEventHandler): this;
-    off(type: 'pm:positionchange', fn?: PM.PositionChangeEventHandler): this;
+    /** Fired coordinates of the layer changed. */
+    on(type: 'pm:change', fn: PM.PositionChangeEventHandler): this;
+    once(type: 'pm:change', fn: PM.PositionChangeEventHandler): this;
+    off(type: 'pm:change', fn?: PM.PositionChangeEventHandler): this;
 
     /******************************************
      *

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -281,6 +281,11 @@ declare module 'leaflet' {
     once(type: 'pm:intersect', fn: PM.IntersectEventHandler): this;
     off(type: 'pm:intersect', fn?: PM.IntersectEventHandler): this;
 
+    /** Fired when position / coordinates of a layer changed. */
+    on(type: 'pm:positionchange', fn: PM.PositionChangeEventHandler): this;
+    once(type: 'pm:positionchange', fn: PM.PositionChangeEventHandler): this;
+    off(type: 'pm:positionchange', fn?: PM.PositionChangeEventHandler): this;
+
     /******************************************
      *
      * TODO: EDIT MODE EVENTS ON MAP ONLY
@@ -341,6 +346,16 @@ declare module 'leaflet' {
     on(type: 'pm:dragend', fn: PM.DragEndEventHandler): this;
     once(type: 'pm:dragend', fn: PM.DragEndEventHandler): this;
     off(type: 'pm:dragend', fn?: PM.DragEndEventHandler): this;
+
+    /** Fired when drag mode on a layer is enabled. */
+    on(type: 'pm:dragenable', fn: PM.DragEnableEventHandler): this;
+    once(type: 'pm:dragenable', fn: PM.DragEnableEventHandler): this;
+    off(type: 'pm:dragenable', fn?: PM.DragEnableEventHandler): this;
+
+    /** Fired when drag mode on a layer is disabled. */
+    on(type: 'pm:dragdisable', fn: PM.DragDisableEventHandler): this;
+    once(type: 'pm:dragdisable', fn: PM.DragDisableEventHandler): this;
+    off(type: 'pm:dragdisable', fn?: PM.DragDisableEventHandler): this;
 
     /******************************************
      *
@@ -1332,6 +1347,11 @@ declare module 'leaflet' {
       layer: L.Layer;
       intersection: L.LatLng;
     }) => void;
+    export type PositionChangeEventHandler = (e: {
+      shape: PM.SUPPORTED_SHAPES;
+      layer: L.Layer;
+      latlng: L.LatLng | L.LatLng[];
+    }) => void;
 
     /**
      * EDIT MODE MAP EVENT HANDLERS
@@ -1368,6 +1388,15 @@ declare module 'leaflet' {
       layer: L.Layer;
       shape: PM.SUPPORTED_SHAPES;
     }) => void;
+    export type DragEnableEventHandler = (e: {
+      layer: L.Layer;
+      shape: PM.SUPPORTED_SHAPES;
+    }) => void;
+    export type DragDisableEventHandler = (e: {
+      layer: L.Layer;
+      shape: PM.SUPPORTED_SHAPES;
+    }) => void;
+
 
     /**
      * REMOVE MODE LAYER EVENT HANDLERS
@@ -1405,8 +1434,12 @@ declare module 'leaflet' {
     export type RotateEnableEventHandler = (e: {
       layer: L.Layer;
       helpLayer: L.Layer;
+      shape: PM.SUPPORTED_SHAPES;
     }) => void;
-    export type RotateDisableEventHandler = (e: { layer: L.Layer }) => void;
+    export type RotateDisableEventHandler = (e: {
+      layer: L.Layer
+      shape: PM.SUPPORTED_SHAPES;
+    }) => void;
     export type RotateStartEventHandler = (e: {
       layer: L.Layer;
       helpLayer: L.Layer;

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -282,9 +282,9 @@ declare module 'leaflet' {
     off(type: 'pm:intersect', fn?: PM.IntersectEventHandler): this;
 
     /** Fired coordinates of the layer changed. */
-    on(type: 'pm:change', fn: PM.PositionChangeEventHandler): this;
-    once(type: 'pm:change', fn: PM.PositionChangeEventHandler): this;
-    off(type: 'pm:change', fn?: PM.PositionChangeEventHandler): this;
+    on(type: 'pm:change', fn: PM.ChangeEventHandler): this;
+    once(type: 'pm:change', fn: PM.ChangeEventHandler): this;
+    off(type: 'pm:change', fn?: PM.ChangeEventHandler): this;
 
     /******************************************
      *
@@ -1347,10 +1347,10 @@ declare module 'leaflet' {
       layer: L.Layer;
       intersection: L.LatLng;
     }) => void;
-    export type PositionChangeEventHandler = (e: {
+    export type ChangeEventHandler = (e: {
       shape: PM.SUPPORTED_SHAPES;
       layer: L.Layer;
-      latlng: L.LatLng | L.LatLng[];
+      latlngs: L.LatLng | L.LatLng[];
     }) => void;
 
     /**

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -185,7 +185,7 @@ Draw.Circle = Draw.extend({
       this._layerGroup && this._layerGroup.hasLayer(this._centerMarker)
         ? this._centerMarker.getLatLng()
         : this._hintMarker.getLatLng();
-    this._firePositionChange(latlng, 'Draw');
+    this._fireChange(latlng, 'Draw');
   },
   _placeCenterMarker(e) {
     this._layerGroup.addLayer(this._layer);
@@ -221,7 +221,7 @@ Draw.Circle = Draw.extend({
       );
 
       this._fireCenterPlaced();
-      this._firePositionChange(this._layer.getLatLng(), 'Draw');
+      this._fireChange(this._layer.getLatLng(), 'Draw');
     }
   },
   _finishShape(e) {

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -180,6 +180,12 @@ Draw.Circle = Draw.extend({
     }
 
     this._handleHintMarkerSnapping();
+
+    const latlng =
+      this._layerGroup && this._layerGroup.hasLayer(this._centerMarker)
+        ? this._centerMarker.getLatLng()
+        : this._hintMarker.getLatLng();
+    this._firePositionChange(latlng, 'Draw');
   },
   _placeCenterMarker(e) {
     this._layerGroup.addLayer(this._layer);
@@ -215,6 +221,7 @@ Draw.Circle = Draw.extend({
       );
 
       this._fireCenterPlaced();
+      this._firePositionChange(this._layer.getLatLng(), 'Draw');
     }
   },
   _finishShape(e) {

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -22,13 +22,18 @@ Draw.CircleMarker = Draw.Marker.extend({
 
     // Draw the CircleMarker like a Circle
     if (this.options.editable) {
+      // we need to set the radius to 0 without overwriting the CircleMarker style
+      const templineStyle = {};
+      L.setOptions(templineStyle, this.options.templineStyle);
+      templineStyle.radius = 0;
+
       // create a new layergroup
       this._layerGroup = new L.LayerGroup();
       this._layerGroup._pmTempLayer = true;
       this._layerGroup.addTo(this._map);
 
       // this is the circle we want to draw
-      this._layer = L.circleMarker([0, 0], this.options.templineStyle);
+      this._layer = L.circleMarker([0, 0], templineStyle);
       this._setPane(this._layer, 'layerPane');
       this._layer._pmTempLayer = true;
 
@@ -205,6 +210,7 @@ Draw.CircleMarker = Draw.Marker.extend({
       );
 
       this._fireCenterPlaced();
+      this._firePositionChange(this._layer.getLatLng(), 'Draw');
     }
   },
   _syncHintLine() {
@@ -247,6 +253,12 @@ Draw.CircleMarker = Draw.Marker.extend({
     }
 
     this._handleHintMarkerSnapping();
+
+    const latlng =
+      this._layerGroup && this._layerGroup.hasLayer(this._centerMarker)
+        ? this._centerMarker.getLatLng()
+        : this._hintMarker.getLatLng();
+    this._firePositionChange(latlng, 'Draw');
   },
   isRelevantMarker(layer) {
     return (

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -210,7 +210,7 @@ Draw.CircleMarker = Draw.Marker.extend({
       );
 
       this._fireCenterPlaced();
-      this._firePositionChange(this._layer.getLatLng(), 'Draw');
+      this._fireChange(this._layer.getLatLng(), 'Draw');
     }
   },
   _syncHintLine() {
@@ -258,7 +258,7 @@ Draw.CircleMarker = Draw.Marker.extend({
       this._layerGroup && this._layerGroup.hasLayer(this._centerMarker)
         ? this._centerMarker.getLatLng()
         : this._hintMarker.getLatLng();
-    this._firePositionChange(latlng, 'Draw');
+    this._fireChange(latlng, 'Draw');
   },
   isRelevantMarker(layer) {
     return (

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -254,4 +254,5 @@ Draw.Cut = Draw.Polygon.extend({
     }
     return diff;
   },
+  _positionChange: L.Util.falseFn,
 });

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -254,5 +254,5 @@ Draw.Cut = Draw.Polygon.extend({
     }
     return diff;
   },
-  _positionChange: L.Util.falseFn,
+  _change: L.Util.falseFn,
 });

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -379,6 +379,6 @@ Draw.Line = Draw.extend({
     this._hintMarker.setTooltipContent(text);
   },
   _positionChange(latlngs) {
-    this._firePositionChange(latlngs, 'Draw');
+    this._fireChange(latlngs, 'Draw');
   },
 });

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -178,7 +178,7 @@ Draw.Line = Draw.extend({
     }
     const latlngs = this._layer._defaultShape().slice();
     latlngs.push(this._hintMarker.getLatLng());
-    this._positionChange(latlngs);
+    this._change(latlngs);
   },
   hasSelfIntersection() {
     // check for self intersection of the layer and return true/false
@@ -261,7 +261,7 @@ Draw.Line = Draw.extend({
     this._hintline.setLatLngs([latlng, latlng]);
 
     this._fireVertexAdded(newMarker, undefined, latlng, 'Draw');
-    this._positionChange(this._layer.getLatLngs());
+    this._change(this._layer.getLatLngs());
     // check if we should finish on snap
     if (this.options.finishOn === 'snap' && this._hintMarker._snapped) {
       this._finishShape(e);
@@ -301,7 +301,7 @@ Draw.Line = Draw.extend({
     this._setTooltipText();
 
     this._fireVertexRemoved(marker, indexPath, 'Draw');
-    this._positionChange(this._layer.getLatLngs());
+    this._change(this._layer.getLatLngs());
   },
   _finishShape() {
     // if self intersection is not allowed, do not finish the shape!
@@ -378,7 +378,7 @@ Draw.Line = Draw.extend({
     }
     this._hintMarker.setTooltipContent(text);
   },
-  _positionChange(latlngs) {
+  _change(latlngs) {
     this._fireChange(latlngs, 'Draw');
   },
 });

--- a/src/js/Draw/L.PM.Draw.Line.js
+++ b/src/js/Draw/L.PM.Draw.Line.js
@@ -176,6 +176,9 @@ Draw.Line = Draw.extend({
     if (!this.options.allowSelfIntersection) {
       this._handleSelfIntersection(true, e.latlng);
     }
+    const latlngs = this._layer._defaultShape().slice();
+    latlngs.push(this._hintMarker.getLatLng());
+    this._positionChange(latlngs);
   },
   hasSelfIntersection() {
     // check for self intersection of the layer and return true/false
@@ -258,7 +261,7 @@ Draw.Line = Draw.extend({
     this._hintline.setLatLngs([latlng, latlng]);
 
     this._fireVertexAdded(newMarker, undefined, latlng, 'Draw');
-
+    this._positionChange(this._layer.getLatLngs());
     // check if we should finish on snap
     if (this.options.finishOn === 'snap' && this._hintMarker._snapped) {
       this._finishShape(e);
@@ -298,6 +301,7 @@ Draw.Line = Draw.extend({
     this._setTooltipText();
 
     this._fireVertexRemoved(marker, indexPath, 'Draw');
+    this._positionChange(this._layer.getLatLngs());
   },
   _finishShape() {
     // if self intersection is not allowed, do not finish the shape!
@@ -373,5 +377,8 @@ Draw.Line = Draw.extend({
       text = getTranslation('tooltips.finishLine');
     }
     this._hintMarker.setTooltipContent(text);
+  },
+  _positionChange(latlngs) {
+    this._firePositionChange(latlngs, 'Draw');
   },
 });

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -119,6 +119,8 @@ Draw.Marker = Draw.extend({
       fakeDragEvent.target = this._hintMarker;
       this._handleSnapping(fakeDragEvent);
     }
+
+    this._firePositionChange(this._hintMarker.getLatLng(), 'Draw');
   },
   _createMarker(e) {
     if (!e.latlng) {

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -120,7 +120,7 @@ Draw.Marker = Draw.extend({
       this._handleSnapping(fakeDragEvent);
     }
 
-    this._firePositionChange(this._hintMarker.getLatLng(), 'Draw');
+    this._fireChange(this._hintMarker.getLatLng(), 'Draw');
   },
   _createMarker(e) {
     if (!e.latlng) {

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -201,6 +201,12 @@ Draw.Rectangle = Draw.extend({
       fakeDragEvent.target = this._hintMarker;
       this._handleSnapping(fakeDragEvent);
     }
+
+    const latlngs =
+      this._layerGroup && this._layerGroup.hasLayer(this._layer)
+        ? this._layer.getLatLngs()
+        : [this._hintMarker.getLatLng()];
+    this._firePositionChange(latlngs, 'Draw');
   },
   _syncRectangleSize() {
     const A = fixLatOffset(this._startMarker.getLatLng(), this._map);

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -206,7 +206,7 @@ Draw.Rectangle = Draw.extend({
       this._layerGroup && this._layerGroup.hasLayer(this._layer)
         ? this._layer.getLatLngs()
         : [this._hintMarker.getLatLng()];
-    this._firePositionChange(latlngs, 'Draw');
+    this._fireChange(latlngs, 'Draw');
   },
   _syncRectangleSize() {
     const A = fixLatOffset(this._startMarker.getLatLng(), this._map);

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -196,7 +196,7 @@ Edit.Circle = Edit.extend({
     this._updateHiddenPolyCircle();
 
     this._fireCenterPlaced('Edit');
-    this._firePositionChange(this._layer.getLatLng(), 'Edit');
+    this._fireChange(this._layer.getLatLng(), 'Edit');
   },
   _syncCircleRadius() {
     const A = this._centerMarker.getLatLng();
@@ -219,7 +219,7 @@ Edit.Circle = Edit.extend({
     }
 
     this._updateHiddenPolyCircle();
-    this._firePositionChange(this._layer.getLatLng(), 'Edit');
+    this._fireChange(this._layer.getLatLng(), 'Edit');
   },
   _syncHintLine() {
     const A = this._centerMarker.getLatLng();

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -196,6 +196,7 @@ Edit.Circle = Edit.extend({
     this._updateHiddenPolyCircle();
 
     this._fireCenterPlaced('Edit');
+    this._firePositionChange(this._layer.getLatLng(), 'Edit');
   },
   _syncCircleRadius() {
     const A = this._centerMarker.getLatLng();
@@ -218,6 +219,7 @@ Edit.Circle = Edit.extend({
     }
 
     this._updateHiddenPolyCircle();
+    this._firePositionChange(this._layer.getLatLng(), 'Edit');
   },
   _syncHintLine() {
     const A = this._centerMarker.getLatLng();
@@ -269,7 +271,7 @@ Edit.Circle = Edit.extend({
       return;
     }
     delete this._vertexValidationReset;
-    this._fireDragStart(e);
+    this._fireDragStart();
   },
   _onCircleDrag(e) {
     if (this._vertexValidationReset) {

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -228,7 +228,7 @@ Edit.CircleMarker = Edit.extend({
     this._updateHiddenPolyCircle();
 
     this._fireCenterPlaced('Edit');
-    this._firePositionChange(this._layer.getLatLng(), 'Edit');
+    this._fireChange(this._layer.getLatLng(), 'Edit');
   },
   _syncMarkers() {
     const center = this._layer.getLatLng();
@@ -264,7 +264,7 @@ Edit.CircleMarker = Edit.extend({
     }
 
     this._updateHiddenPolyCircle();
-    this._firePositionChange(this._layer.getLatLng(), 'Edit');
+    this._fireChange(this._layer.getLatLng(), 'Edit');
   },
   _syncHintLine() {
     const A = this._centerMarker.getLatLng();

--- a/src/js/Edit/L.PM.Edit.CircleMarker.js
+++ b/src/js/Edit/L.PM.Edit.CircleMarker.js
@@ -228,6 +228,7 @@ Edit.CircleMarker = Edit.extend({
     this._updateHiddenPolyCircle();
 
     this._fireCenterPlaced('Edit');
+    this._firePositionChange(this._layer.getLatLng(), 'Edit');
   },
   _syncMarkers() {
     const center = this._layer.getLatLng();
@@ -263,6 +264,7 @@ Edit.CircleMarker = Edit.extend({
     }
 
     this._updateHiddenPolyCircle();
+    this._firePositionChange(this._layer.getLatLng(), 'Edit');
   },
   _syncHintLine() {
     const A = this._centerMarker.getLatLng();

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -334,7 +334,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
 
     this._fireVertexAdded(
       newM,
@@ -570,7 +570,7 @@ Edit.Line = Edit.extend({
     // fire vertex removal event
     // TODO: maybe fire latlng as well?
     this._fireVertexRemoved(marker, indexPath);
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
   },
   updatePolygonCoordsFromMarkerDrag(marker) {
     // update polygon coords
@@ -749,7 +749,7 @@ Edit.Line = Edit.extend({
       this._handleLayerStyle();
     }
     this._fireMarkerDrag(e, indexPath);
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
   },
   _onMarkerDragEnd(e) {
     const marker = e.target;
@@ -803,7 +803,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
   },
   _onVertexClick(e) {
     const vertex = e.target;

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -334,6 +334,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
 
     this._fireVertexAdded(
       newM,
@@ -569,6 +570,7 @@ Edit.Line = Edit.extend({
     // fire vertex removal event
     // TODO: maybe fire latlng as well?
     this._fireVertexRemoved(marker, indexPath);
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
   },
   updatePolygonCoordsFromMarkerDrag(marker) {
     // update polygon coords
@@ -747,6 +749,7 @@ Edit.Line = Edit.extend({
       this._handleLayerStyle();
     }
     this._fireMarkerDrag(e, indexPath);
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
   },
   _onMarkerDragEnd(e) {
     const marker = e.target;
@@ -800,6 +803,7 @@ Edit.Line = Edit.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
   },
   _onVertexClick(e) {
     const vertex = e.target;

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -117,6 +117,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     this._adjustRectangleForMarkerMove(draggedMarker);
 
     this._fireMarkerDrag(e);
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
   },
 
   _onMarkerDragEnd(e) {
@@ -136,6 +137,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
+    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
   },
 
   // adjusts the rectangle's size and bounds whenever a marker is moved

--- a/src/js/Edit/L.PM.Edit.Rectangle.js
+++ b/src/js/Edit/L.PM.Edit.Rectangle.js
@@ -117,7 +117,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     this._adjustRectangleForMarkerMove(draggedMarker);
 
     this._fireMarkerDrag(e);
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
   },
 
   _onMarkerDragEnd(e) {
@@ -137,7 +137,7 @@ Edit.Rectangle = Edit.Polygon.extend({
     // fire edit event
     this._fireEdit();
     this._layerEdited = true;
-    this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+    this._fireChange(this._layer.getLatLngs(), 'Edit');
   },
 
   // adjusts the rectangle's size and bounds whenever a marker is moved

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -69,7 +69,7 @@ const DragMixin = {
       }
     }
 
-    // TODO: should we add Events "enabledrag" / "disabledrag"?
+    this._fireDragEnable();
   },
   disableLayerDrag() {
     this._layerDragEnabled = false;
@@ -115,6 +115,13 @@ const DragMixin = {
         );
       }
     }
+
+    if (this._layerDragged) {
+      this._fireUpdate();
+    }
+    this._layerDragged = false;
+
+    this._fireDragDisable();
   },
   // TODO: make this private in the next major release
   dragging() {
@@ -302,6 +309,8 @@ const DragMixin = {
       this._layer.pm._updateHiddenPolyCircle();
     }
 
+    this._layerDragged = true;
+
     // timeout to prevent click event after drag :-/
     // TODO: do it better as soon as leaflet has a way to do it better :-)
     window.setTimeout(() => {
@@ -317,7 +326,6 @@ const DragMixin = {
 
       // fire edit
       this._fireEdit();
-      this._layerEdited = true;
     }, 10);
 
     return true;
@@ -356,6 +364,7 @@ const DragMixin = {
       const newCoords = moveCoords([this._layer.getLatLng()]);
       // set new coordinates and redraw
       this._layer.setLatLng(newCoords[0]);
+      this._firePositionChange(this._layer.getLatLng(), 'Edit');
     } else if (
       this._layer instanceof L.CircleMarker ||
       this._layer instanceof L.Marker
@@ -369,6 +378,7 @@ const DragMixin = {
       const newCoords = moveCoords([coordsRefernce]);
       // set new coordinates and redraw
       this._layer.setLatLng(newCoords[0]);
+      this._firePositionChange(this._layer.getLatLng(), 'Edit');
     } else if (this._layer instanceof L.ImageOverlay) {
       // create the new coordinates array
       const newCoords = moveCoords([
@@ -377,12 +387,14 @@ const DragMixin = {
       ]);
       // set new coordinates and redraw
       this._layer.setBounds(newCoords);
+      this._firePositionChange(this._layer.getBounds(), 'Edit');
     } else {
       // create the new coordinates array
       const newCoords = moveCoords(this._layer.getLatLngs());
 
       // set new coordinates and redraw
       this._layer.setLatLngs(newCoords);
+      this._firePositionChange(this._layer.getLatLngs(), 'Edit');
     }
 
     // save current latlng for next delta calculation

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -364,7 +364,7 @@ const DragMixin = {
       const newCoords = moveCoords([this._layer.getLatLng()]);
       // set new coordinates and redraw
       this._layer.setLatLng(newCoords[0]);
-      this._firePositionChange(this._layer.getLatLng(), 'Edit');
+      this._fireChange(this._layer.getLatLng(), 'Edit');
     } else if (
       this._layer instanceof L.CircleMarker ||
       this._layer instanceof L.Marker
@@ -378,7 +378,7 @@ const DragMixin = {
       const newCoords = moveCoords([coordsRefernce]);
       // set new coordinates and redraw
       this._layer.setLatLng(newCoords[0]);
-      this._firePositionChange(this._layer.getLatLng(), 'Edit');
+      this._fireChange(this._layer.getLatLng(), 'Edit');
     } else if (this._layer instanceof L.ImageOverlay) {
       // create the new coordinates array
       const newCoords = moveCoords([
@@ -387,14 +387,14 @@ const DragMixin = {
       ]);
       // set new coordinates and redraw
       this._layer.setBounds(newCoords);
-      this._firePositionChange(this._layer.getBounds(), 'Edit');
+      this._fireChange(this._layer.getBounds(), 'Edit');
     } else {
       // create the new coordinates array
       const newCoords = moveCoords(this._layer.getLatLngs());
 
       // set new coordinates and redraw
       this._layer.setLatLngs(newCoords);
-      this._firePositionChange(this._layer.getLatLngs(), 'Edit');
+      this._fireChange(this._layer.getLatLngs(), 'Edit');
     }
 
     // save current latlng for next delta calculation

--- a/src/js/Mixins/Events.js
+++ b/src/js/Mixins/Events.js
@@ -344,13 +344,13 @@ const EventMixin = {
   },
 
   // Fired when position / coordinates of a layer changed
-  _firePositionChange(latlng, source = 'Edit', customPayload = {}) {
+  _fireChange(latlngs, source = 'Edit', customPayload = {}) {
     this.__fire(
       this._layer,
-      'pm:positionchange',
+      'pm:change',
       {
         layer: this._layer,
-        latlng,
+        latlngs,
         shape: this.getShape(),
       },
       source,

--- a/src/js/Mixins/Events.js
+++ b/src/js/Mixins/Events.js
@@ -343,7 +343,7 @@ const EventMixin = {
     );
   },
 
-  // Fired when position / coordinates of a layer changed
+  // Fired coordinates of the layer changed
   _fireChange(latlngs, source = 'Edit', customPayload = {}) {
     this.__fire(
       this._layer,

--- a/src/js/Mixins/Events.js
+++ b/src/js/Mixins/Events.js
@@ -224,6 +224,26 @@ const EventMixin = {
       customPayload
     );
   },
+  // Fired when layer is enabled for editing
+  _fireDragEnable(source = 'Edit', customPayload = {}) {
+    this.__fire(
+      this._layer,
+      'pm:dragenable',
+      { layer: this._layer, shape: this.getShape() },
+      source,
+      customPayload
+    );
+  },
+  // Fired when layer is disabled for editing
+  _fireDragDisable(source = 'Edit', customPayload = {}) {
+    this.__fire(
+      this._layer,
+      'pm:dragdisable',
+      { layer: this._layer, shape: this.getShape() },
+      source,
+      customPayload
+    );
+  },
   // Fired when a layer is removed
   _fireRemove(
     fireLayer,
@@ -323,6 +343,21 @@ const EventMixin = {
     );
   },
 
+  // Fired when position / coordinates of a layer changed
+  _firePositionChange(latlng, source = 'Edit', customPayload = {}) {
+    this.__fire(
+      this._layer,
+      'pm:positionchange',
+      {
+        layer: this._layer,
+        latlng,
+        shape: this.getShape(),
+      },
+      source,
+      customPayload
+    );
+  },
+
   // Snapping Events
   // Fired during a marker move/drag and other layers are existing
   _fireSnapDrag(fireLayer, eventInfo, source = 'Snapping', customPayload = {}) {
@@ -351,6 +386,7 @@ const EventMixin = {
       {
         layer: this._layer,
         helpLayer: this._rotatePoly,
+        shape: this.getShape(),
       },
       source,
       customPayload
@@ -363,6 +399,7 @@ const EventMixin = {
       'pm:rotatedisable',
       {
         layer: this._layer,
+        shape: this.getShape(),
       },
       source,
       customPayload
@@ -393,6 +430,7 @@ const EventMixin = {
     fireLayer,
     angleDiff,
     oldLatLngs,
+    rotationLayer = this._rotationLayer,
     source = 'Rotation',
     customPayload = {}
   ) {
@@ -400,13 +438,13 @@ const EventMixin = {
       fireLayer,
       'pm:rotate',
       {
-        layer: this._rotationLayer,
+        layer: rotationLayer,
         helpLayer: this._layer,
         startAngle: this._startAngle,
-        angle: this._rotationLayer.pm.getAngle(),
+        angle: rotationLayer.pm.getAngle(),
         angleDiff,
         oldLatLngs,
-        newLatLngs: this._rotationLayer.getLatLngs(),
+        newLatLngs: rotationLayer.getLatLngs(),
       },
       source,
       customPayload

--- a/src/js/Mixins/Rotating.js
+++ b/src/js/Mixins/Rotating.js
@@ -87,7 +87,7 @@ const RotateMixin = {
 
     this._fireRotation(this._rotationLayer, angleDiff, oldLatLngs);
     this._fireRotation(this._map, angleDiff, oldLatLngs);
-    this._rotationLayer.pm._firePositionChange(
+    this._rotationLayer.pm._fireChange(
       this._rotationLayer.getLatLngs(),
       'Rotation'
     );
@@ -247,7 +247,7 @@ const RotateMixin = {
     this._fireRotation(this._layer, angleDiff, oldLatLngs, this._layer);
     this._fireRotation(this._map, angleDiff, oldLatLngs, this._layer);
     delete this._startAngle;
-    this._firePositionChange(this._layer.getLatLngs(), 'Rotation');
+    this._fireChange(this._layer.getLatLngs(), 'Rotation');
   },
   rotateLayerToAngle(angle) {
     const newAnlge = angle - this.getAngle();

--- a/src/js/Mixins/Rotating.js
+++ b/src/js/Mixins/Rotating.js
@@ -87,6 +87,10 @@ const RotateMixin = {
 
     this._fireRotation(this._rotationLayer, angleDiff, oldLatLngs);
     this._fireRotation(this._map, angleDiff, oldLatLngs);
+    this._rotationLayer.pm._firePositionChange(
+      this._rotationLayer.getLatLngs(),
+      'Rotation'
+    );
   },
   _onRotateEnd() {
     const startAngle = this._startAngle;
@@ -108,6 +112,8 @@ const RotateMixin = {
     this._rotationLayer.pm._fireEdit(this._rotationLayer, 'Rotation');
 
     this._preventRenderingMarkers(false);
+
+    this._layerRotated = true;
   },
   _rotateLayer(radiant, latlngs, origin, _matrix, map) {
     const originPoint = _toPoint(map, origin);
@@ -176,6 +182,10 @@ const RotateMixin = {
   },
   disableRotate() {
     if (this.rotateEnabled()) {
+      if (this._rotatePoly.pm._layerRotated) {
+        this._fireUpdate();
+      }
+      this._rotatePoly.pm._layerRotated = false;
       // delete the temp polygon
       this._rotatePoly.pm.disable();
       this._rotatePoly.remove();
@@ -197,6 +207,8 @@ const RotateMixin = {
   },
   // angle is clockwise (0-360)
   rotateLayer(angle) {
+    const oldAngle = this.getAngle();
+    const oldLatLngs = this._layer.getLatLngs();
     const rads = angle * (Math.PI / 180);
     this._layer.setLatLngs(
       this._rotateLayer(
@@ -226,6 +238,16 @@ const RotateMixin = {
       );
       this._rotatePoly.pm._initMarkers();
     }
+
+    // TODO: for negative angle change the difference is always (360 - angle), do we want this?
+    let angleDiff = this.getAngle() - oldAngle;
+    angleDiff = angleDiff < 0 ? angleDiff + 360 : angleDiff;
+
+    this._startAngle = oldAngle;
+    this._fireRotation(this._layer, angleDiff, oldLatLngs, this._layer);
+    this._fireRotation(this._map, angleDiff, oldLatLngs, this._layer);
+    delete this._startAngle;
+    this._firePositionChange(this._layer.getLatLngs(), 'Rotation');
   },
   rotateLayerToAngle(angle) {
     const newAnlge = angle - this.getAngle();

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -136,6 +136,7 @@ const SnapMixin = {
     if (closestLayer.distance < minDistance) {
       // snap the marker
       marker._orgLatLng = marker.getLatLng();
+      // TODO: if the origin marker has a altitude is applied to the snapped layer too, do we want this?
       marker.setLatLng(snapLatLng);
 
       marker._snapped = true;


### PR DESCRIPTION
- Fixes #1074 
- Fixes #1080 

New events:
- `pm:dragenable`
- `pm:dragdisable`
- `pm:positionchange`

Fixed firing events when layer is updated by dragging or rotating `pm:update`. And fire `pm:rotate` if manually the layer is rotated.