### PR TITLE
Set title on the buttonContainer instead of the icon

### DIFF
--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -152,6 +152,8 @@ describe('Testing the Toolbar', () => {
     });
 
     cy.get('.leaflet-buttons-control-button .leaflet-pm-icon-circle-marker')
+      .parent()
+      .parent()
       .should('have.attr', 'title')
       .and('include', 'Dibujar Marcador de Circulo');
   });
@@ -210,6 +212,8 @@ describe('Testing the Toolbar', () => {
       });
       cy.toolbarButtonContainer('clickButton', map).then((container) => {
         cy.get(container[0].children[0].children[0])
+          .parent()
+          .parent()
           .should('have.attr', 'title')
           .and('include', 'Count layers');
         container[0].children[0].click(); // button
@@ -250,6 +254,8 @@ describe('Testing the Toolbar', () => {
 
       cy.toolbarButtonContainer('PolygonCopy', map).then((container) => {
         cy.get(container[0].children[0].children[0])
+          .parent()
+          .parent()
           .should('have.attr', 'title')
           .and('include', 'Display text on hover button');
         cy.get(container[0].children[0]).click(); // button

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -96,6 +96,10 @@ const PMButton = L.Control.extend({
       this._container
     );
 
+    if (button.title) {
+      buttonContainer.setAttribute('title', button.title);
+    }
+
     // the button itself
     const newButton = L.DomUtil.create(
       'a',
@@ -190,10 +194,6 @@ const PMButton = L.Control.extend({
 
     if (button.toggleStatus) {
       L.DomUtil.addClass(buttonContainer, 'active');
-    }
-
-    if (button.title) {
-      buttonContainer.setAttribute('title', button.title);
     }
 
     const image = L.DomUtil.create('div', 'control-icon', newButton);

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -192,11 +192,11 @@ const PMButton = L.Control.extend({
       L.DomUtil.addClass(buttonContainer, 'active');
     }
 
-    const image = L.DomUtil.create('div', 'control-icon', newButton);
-
     if (button.title) {
-      image.setAttribute('title', button.title);
+      buttonContainer.setAttribute('title', button.title);
     }
+
+    const image = L.DomUtil.create('div', 'control-icon', newButton);
 
     if (button.iconUrl) {
       image.setAttribute('src', button.iconUrl);


### PR DESCRIPTION
Set the title on the buttonContainer instead of the icon child element because it is not shown on the mouse over the buttonContainer padding zone.