### PR TITLE
fix: Update TS so that there is no error when compiling

### DIFF
--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1112,7 +1112,7 @@ declare module 'leaflet' {
 
       /** Adds custom button (default:true) */
       // The type of custom buttons are always boolean but TS needs the other types defined too.
-      [key: string]: L.ControlPosition | BlockPositions | boolean;
+      [key: string]: L.ControlPosition | BlockPositions | boolean | undefined;
     }
 
     /** the position of each block. */


### PR DESCRIPTION

After updating to the latest version 2.12.0 from version 2.7.0 I have found a compilation error.

Doing this small modification fixes the compilation problems.

Very good project.


```
Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1054:7 - error TS2411: Property 'position' of type 'ControlPosition | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1054       position?: L.ControlPosition;
           ~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1057:7 - error TS2411: Property 'positions' of type 'BlockPositions | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1057       positions?: BlockPositions;
           ~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1060:7 - error TS2411: Property 'drawMarker' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1060       drawMarker?: boolean;
           ~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1063:7 - error TS2411: Property 'drawCircleMarker' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1063       drawCircleMarker?: boolean;
           ~~~~~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1066:7 - error TS2411: Property 'drawPolyline' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1066       drawPolyline?: boolean;
           ~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1069:7 - error TS2411: Property 'drawRectangle' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1069       drawRectangle?: boolean;
           ~~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1072:7 - error TS2411: Property 'drawPolygon' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1072       drawPolygon?: boolean;
           ~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1075:7 - error TS2411: Property 'drawCircle' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1075       drawCircle?: boolean;
           ~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1078:7 - error TS2411: Property 'editMode' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1078       editMode?: boolean;
           ~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1081:7 - error TS2411: Property 'dragMode' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1081       dragMode?: boolean;
           ~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1084:7 - error TS2411: Property 'cutPolygon' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1084       cutPolygon?: boolean;
           ~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1087:7 - error TS2411: Property 'removalMode' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1087       removalMode?: boolean;
           ~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1090:7 - error TS2411: Property 'rotateMode' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1090       rotateMode?: boolean;
           ~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1093:7 - error TS2411: Property 'oneBlock' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1093       oneBlock?: boolean;
           ~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1096:7 - error TS2411: Property 'drawControls' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1096       drawControls?: boolean;
           ~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1099:7 - error TS2411: Property 'editControls' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1099       editControls?: boolean;
           ~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1102:7 - error TS2411: Property 'customControls' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1102       customControls?: boolean;
           ~~~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1105:7 - error TS2411: Property 'optionsControls' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1105       optionsControls?: boolean;
           ~~~~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1108:7 - error TS2411: Property 'pinningOption' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1108       pinningOption?: boolean;
           ~~~~~~~~~~~~~


Error: node_modules/@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.d.ts:1111:7 - error TS2411: Property 'snappingOption' of type 'boolean | undefined' is not assignable to 'string' index type 'boolean | ControlPosition | BlockPositions'.

1111       snappingOption?: boolean;
           ~~~~~~~~~~~~~~
```