### PR TITLE
Avoid empty clientX and clientY values when dragging Marker (Safari iOS)

### DIFF
--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -135,11 +135,11 @@ const DragMixin = {
   // We need to simulate a mousedown event on the layer object. We can't just use layer.on('mousedown') because on touch devices the event is not fired if user presses on the layer and then drag it.
   // With checking on touchstart and mousedown on the DOM element we can listen on the needed events
   _simulateMouseDownEvent(e) {
+    const first = e.touches ? e.touches[0] : e;
     const evt = {
-      originalEvent: e,
+      originalEvent: first,
       target: this._layer,
     };
-    const first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
     evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
@@ -148,11 +148,11 @@ const DragMixin = {
     return false;
   },
   _simulateMouseMoveEvent(e) {
+    const first = e.touches ? e.touches[0] : e;
     const evt = {
-      originalEvent: e,
+      originalEvent: first,
       target: this._layer,
     };
-    const first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
     evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);

--- a/src/js/Mixins/Rotating.js
+++ b/src/js/Mixins/Rotating.js
@@ -107,8 +107,12 @@ const RotateMixin = {
     // store the new latlngs
     this._rotationLayer.pm._rotateOrgLatLng = copyLatLngs(this._rotationLayer);
 
-    this._fireRotationEnd(this._rotationLayer, startAngle, originLatLngs);
-    this._fireRotationEnd(this._map, startAngle, originLatLngs);
+    this._fireRotationEnd(this._rotationLayer, startAngle, originLatLngs, undefined, {
+      matrix: this._matrix
+    });
+    this._fireRotationEnd(this._map, startAngle, originLatLngs, undefined, {
+      matrix: this._matrix
+    });
     this._rotationLayer.pm._fireEdit(this._rotationLayer, 'Rotation');
 
     this._preventRenderingMarkers(false);

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -183,7 +183,9 @@ const PMButton = L.Control.extend({
                 break;
               }
             }
-            this._fireActionClick(action, btnName, button);
+            this._fireActionClick(action, btnName, button, 'ToolBar', {
+              name
+            });
           };
 
           L.DomEvent.addListener(actionNode, 'click', actionClick, this);

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -311,7 +311,7 @@ const Toolbar = L.Class.extend({
       disableOtherButtons: true,
       position: this.options.position,
       tool: 'edit',
-      actions: ['finishMode'],
+      actions: ['finishMode', 'cancel'],
     };
 
     const dragButton = {
@@ -326,7 +326,7 @@ const Toolbar = L.Class.extend({
       disableOtherButtons: true,
       position: this.options.position,
       tool: 'edit',
-      actions: ['finishMode'],
+      actions: ['finishMode', 'cancel'],
     };
 
     const cutButton = {
@@ -362,7 +362,7 @@ const Toolbar = L.Class.extend({
       disableOtherButtons: true,
       position: this.options.position,
       tool: 'edit',
-      actions: ['finishMode'],
+      actions: ['finishMode', 'cancel'],
     };
 
     const rotateButton = {


### PR DESCRIPTION
On mobile safari dragging a Marker gave an error. 
When digging into the code I saw that it calls:
`this._map.mouseEventToContainerPoint(e.originalEvent);`
But originalEvent did not contain a `clientX` and `clientY` property.
In the call `_simulateMouseDownEvent` I've used the later declared first touch event, which has a `ClientX|Y` value.
