### PR TITLE
Avoid empty clientX and clientY values when dragging marker in mobile…

### DIFF
--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -135,11 +135,11 @@ const DragMixin = {
   // We need to simulate a mousedown event on the layer object. We can't just use layer.on('mousedown') because on touch devices the event is not fired if user presses on the layer and then drag it.
   // With checking on touchstart and mousedown on the DOM element we can listen on the needed events
   _simulateMouseDownEvent(e) {
+    const first = e.touches ? e.touches[0] : e;
     const evt = {
-      originalEvent: e,
+      originalEvent: first,
       target: this._layer,
     };
-    const first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
     evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);
@@ -148,11 +148,11 @@ const DragMixin = {
     return false;
   },
   _simulateMouseMoveEvent(e) {
+    const first = e.touches ? e.touches[0] : e;
     const evt = {
-      originalEvent: e,
+      originalEvent: first,
       target: this._layer,
     };
-    const first = e.touches ? e.touches[0] : e;
     // we expect in the function to get the clicked latlng / point
     evt.containerPoint = this._map.mouseEventToContainerPoint(first);
     evt.latlng = this._map.containerPointToLatLng(evt.containerPoint);

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -161,8 +161,9 @@ const DragMixin = {
     return false;
   },
   _simulateMouseUpEvent(e) {
+    const first = e.touches ? e.touches[0] : e;
     const evt = {
-      originalEvent: e,
+      originalEvent: first,
       target: this._layer,
     };
     if (e.type.indexOf('touch') === -1) {


### PR DESCRIPTION
On mobile safari dragging a Marker gave an error. 
When digging into the code I saw that it calls:
`this._map.mouseEventToContainerPoint(e.originalEvent);`
But originalEvent did not contain a `clientX` and `clientY` property.
In the call `_simulateMouseDownEvent` I've used the later declared first touch event, which has a `ClientX|Y` value.
