### PR TITLE
optimize isEmptyDeep

### DIFF
--- a/cypress/integration/helpers.spec.js
+++ b/cypress/integration/helpers.spec.js
@@ -1,35 +1,35 @@
-import { isEmptyDeep } from '../../src/js/helpers';
+import { hasValues } from '../../src/js/helpers';
 
-describe('Helper isEmptyDeep', () => {
-  it('should return true for empty arrays', () => {
-    expect(isEmptyDeep([])).to.be.true;
+describe('Helper hasValues', () => {
+  it('should return false for empty arrays', () => {
+    expect(hasValues([])).to.be.false;
   });
 
-  it('should return true for empty nested arrays', () => {
-    expect(isEmptyDeep([[[]]])).to.be.true;
+  it('should return false for empty nested arrays', () => {
+    expect(hasValues([[[]]])).to.be.false;
   });
 
-  it('should return true for empty-like arrays', () => {
-    expect(isEmptyDeep([undefined, null, ''])).to.be.true;
+  it('should return false for empty-like arrays', () => {
+    expect(hasValues([undefined, null, ''])).to.be.false;
   });
 
-  it('should return true for empty-like nested arrays', () => {
-    expect(isEmptyDeep([[[undefined], [null], ['']]])).to.be.true;
+  it('should return false for empty-like nested arrays', () => {
+    expect(hasValues([[[undefined], [null], ['']]])).to.be.false;
   });
 
-  it('should return false for non-empty arrays', () => {
-    expect(isEmptyDeep([0])).to.be.false;
+  it('should return true for non-empty arrays', () => {
+    expect(hasValues([0])).to.be.true;
   });
 
-  it('should return false for non-empty nested arrays', () => {
-    expect(isEmptyDeep([[[0]]])).to.be.false;
+  it('should return true for non-empty nested arrays', () => {
+    expect(hasValues([[[0]]])).to.be.true;
   });
 
-  it('should return false if there is at least one non-empty value', () => {
-    expect(isEmptyDeep([undefined, null, ''])).to.be.true;
+  it('should return true if there is at least one non-empty value', () => {
+    expect(hasValues([undefined, null, '', 0])).to.be.true;
   });
 
-  it('should return false if there is at least one non-empty nested value', () => {
-    expect(isEmptyDeep([[[null], [undefined, 1]]])).to.be.false;
+  it('should return true if there is at least one non-empty nested value', () => {
+    expect(hasValues([[[undefined], [null, '', 1]]])).to.be.true;
   });
 });

--- a/cypress/integration/helpers.spec.js
+++ b/cypress/integration/helpers.spec.js
@@ -9,15 +9,27 @@ describe('Helper isEmptyDeep', () => {
     expect(isEmptyDeep([[[]]])).to.be.true;
   });
 
-  it('should return true for empty-like nested arrays', () => {
-    expect(isEmptyDeep([[[undefined], [null], '']])).to.be.true;
+  it('should return true for empty-like arrays', () => {
+    expect(isEmptyDeep([undefined, null, ''])).to.be.true;
   });
 
-  it('should return false for a non-empty nested arrays', () => {
-    expect(isEmptyDeep([[[1]]])).to.be.false;
+  it('should return true for empty-like nested arrays', () => {
+    expect(isEmptyDeep([[[undefined], [null], ['']]])).to.be.true;
+  });
+
+  it('should return false for non-empty arrays', () => {
+    expect(isEmptyDeep([0])).to.be.false;
+  });
+
+  it('should return false for non-empty nested arrays', () => {
+    expect(isEmptyDeep([[[0]]])).to.be.false;
   });
 
   it('should return false if there is at least one non-empty value', () => {
+    expect(isEmptyDeep([undefined, null, ''])).to.be.true;
+  });
+
+  it('should return false if there is at least one non-empty nested value', () => {
     expect(isEmptyDeep([[[null], [undefined, 1]]])).to.be.false;
   });
 });

--- a/cypress/integration/helpers.spec.js
+++ b/cypress/integration/helpers.spec.js
@@ -1,0 +1,23 @@
+import { isEmptyDeep } from '../../src/js/helpers';
+
+describe('Helper isEmptyDeep', () => {
+  it('should return true for empty arrays', () => {
+    expect(isEmptyDeep([])).to.be.true;
+  });
+
+  it('should return true for empty nested arrays', () => {
+    expect(isEmptyDeep([[[]]])).to.be.true;
+  });
+
+  it('should return true for empty-like nested arrays', () => {
+    expect(isEmptyDeep([[[undefined], [null], '']])).to.be.true;
+  });
+
+  it('should return false for a non-empty nested arrays', () => {
+    expect(isEmptyDeep([[[1]]])).to.be.false;
+  });
+
+  it('should return false if there is at least one non-empty value', () => {
+    expect(isEmptyDeep([[[null], [undefined, 1]]])).to.be.false;
+  });
+});

--- a/src/js/Edit/L.PM.Edit.Line.js
+++ b/src/js/Edit/L.PM.Edit.Line.js
@@ -2,7 +2,7 @@ import kinks from '@turf/kinks';
 import lineIntersect from '@turf/line-intersect';
 import get from 'lodash/get';
 import Edit from './L.PM.Edit';
-import { isEmptyDeep, removeEmptyCoordRings } from '../helpers';
+import { hasValues, removeEmptyCoordRings } from '../helpers';
 
 import MarkerLimits from '../Mixins/MarkerLimits';
 
@@ -506,7 +506,7 @@ Edit.Line = Edit.extend({
     }
 
     // if no coords are left, remove the layer
-    if (isEmptyDeep(coords)) {
+    if (!hasValues(coords)) {
       this._layer.remove();
     }
 

--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -1,4 +1,4 @@
-import { isEmptyDeep, prioritiseSort } from '../helpers';
+import { hasValues, prioritiseSort } from '../helpers';
 
 const SnapMixin = {
   _initSnappableMarkers() {
@@ -229,8 +229,7 @@ const SnapMixin = {
 
     // also remove everything that has no coordinates yet
     layers = layers.filter(
-      (layer) =>
-        layer._latlng || (layer._latlngs && !isEmptyDeep(layer._latlngs))
+      (layer) => layer._latlng || (layer._latlngs && hasValues(layer._latlngs))
     );
 
     // finally remove everything that's leaflet-geoman specific temporary stuff

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -12,23 +12,20 @@ export function getTranslation(path) {
   return get(translations[lang], path);
 }
 
-export function isEmptyDeep(l) {
-  const hasValues = (list) => {
-    for (let i = 0; i < list.length; i += 1) {
-      const item = list[i];
+export function isEmptyDeep(list) {
+  for (let i = 0; i < list.length; i += 1) {
+    const item = list[i];
 
-      if (Array.isArray(item)) {
-        if (hasValues(item)) {
-          return true;
-        }
-      } else if (item !== null && item !== undefined && item !== '') {
-        return true;
+    if (Array.isArray(item)) {
+      if (!isEmptyDeep(item)) {
+        return false;
       }
+    } else if (item !== null && item !== undefined && item !== '') {
+      return false;
     }
-    return false;
-  };
+  }
 
-  return !hasValues(l);
+  return true;
 }
 
 export function removeEmptyCoordRings(arr) {

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -21,7 +21,7 @@ export function isEmptyDeep(l) {
         if (hasValues(item)) {
           return true;
         }
-      } else if (item != null && item !== '') {
+      } else if (item !== null && item !== undefined && item !== '') {
         return true;
       }
     }

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -12,20 +12,20 @@ export function getTranslation(path) {
   return get(translations[lang], path);
 }
 
-export function isEmptyDeep(list) {
+export function hasValues(list) {
   for (let i = 0; i < list.length; i += 1) {
     const item = list[i];
 
     if (Array.isArray(item)) {
-      if (!isEmptyDeep(item)) {
-        return false;
+      if (hasValues(item)) {
+        return true;
       }
     } else if (item !== null && item !== undefined && item !== '') {
-      return false;
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 
 export function removeEmptyCoordRings(arr) {

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -13,13 +13,22 @@ export function getTranslation(path) {
 }
 
 export function isEmptyDeep(l) {
-  // thanks for the function, Felix Heck
-  const flatten = (list) =>
-    list
-      .filter((x) => ![null, '', undefined].includes(x))
-      .reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+  const hasValues = (list) => {
+    for (let i = 0; i < list.length; i += 1) {
+      const item = list[i];
 
-  return !flatten(l).length;
+      if (Array.isArray(item)) {
+        if (hasValues(item)) {
+          return true;
+        }
+      } else if (item != null && item !== '') {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  return !hasValues(l);
 }
 
 export function removeEmptyCoordRings(arr) {


### PR DESCRIPTION
**TL;DR** `isEmptyDeep` is now 300 times faster

Function `isEmptyDeep` suffered from 2 problems:
1. Unnecessary memory allocations
2. No early return

And since it's used in the snapping code, whenever you have many or just big geometries, the geometry editing is janky.

In this PR I optimized the `isEmptyDeep` function and added the tests for it.

Video explanation:
https://www.loom.com/share/e70379b76e5141d984e773b70dd47921

Benchmark:
https://jsbench.me/h8l8dv6d7h/2