### PR TITLE
Fix focusing manually added Text-Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,14 +774,14 @@ See the available options for `textOptions` in the table below.
 
 The following methods are available on `layer.pm`:
 
-| Method          | Returns       | Description                           |
-| :-------------- | :------------ | :------------------------------------ |
-| focus()         | -             | Activate text editing.                |
-| blur()          | -             | Deactivate text editing.              |
-| hasFocus()      | `Boolean`     | Is text editing active.               |
-| getElement()    | `HTMLElement` | Returns the `<textarea>` DOM element. |
-| setText(`text`) | -             | Set text.                             |
-| getText()       | `String`      | Returns the text.                     |
+| Method          | Returns       | Description                                                           |
+| :-------------- | :------------ | :-------------------------------------------------------------------- |
+| focus()         | -             | Activate text editing. Layer needs first to be enabled `.enable()`.   |
+| blur()          | -             | Deactivate text editing. Layer needs first to be enabled `.enable()`. |
+| hasFocus()      | `Boolean`     | Is text editing active.                                               |
+| getElement()    | `HTMLElement` | Returns the `<textarea>` DOM element.                                 |
+| setText(`text`) | -             | Set text.                                                             |
+| getText()       | `String`      | Returns the text.                                                     |
 
 The following events are available on a layer instance:
 

--- a/cypress/integration/text.spec.js
+++ b/cypress/integration/text.spec.js
@@ -299,7 +299,7 @@ describe('Text Layer', () => {
           text: 'Text Layer',
         }).addTo(map);
         textArea = textLayer.pm.getElement();
-
+        textLayer.pm.enable();
         textLayer.pm.focus();
       });
 
@@ -316,6 +316,7 @@ describe('Text Layer', () => {
       cy.get(mapSelector).click(90, 280);
 
       cy.window().then(() => {
+        textLayer.pm.disable();
         expect(textArea.readOnly).to.eq(true);
         expect(textArea.classList.contains('pm-disabled')).to.eq(true);
       });
@@ -329,7 +330,7 @@ describe('Text Layer', () => {
           text: 'Text Layer',
         }).addTo(map);
         textArea = textLayer.pm.getElement();
-
+        textLayer.pm.enable();
         textLayer.pm.focus();
       });
 
@@ -337,6 +338,9 @@ describe('Text Layer', () => {
         expect(textArea.readOnly).to.eq(false);
         expect(textArea.classList.contains('pm-disabled')).to.eq(false);
         textLayer.pm.blur();
+        expect(textLayer.pm.hasFocus()).to.eq(false);
+
+        textLayer.pm.disable();
         expect(textArea.readOnly).to.eq(true);
         expect(textArea.classList.contains('pm-disabled')).to.eq(true);
       });
@@ -350,7 +354,7 @@ describe('Text Layer', () => {
           text: 'Text Layer',
         }).addTo(map);
         textArea = textLayer.pm.getElement();
-
+        textLayer.pm.enable();
         textLayer.pm.focus();
       });
 
@@ -359,9 +363,11 @@ describe('Text Layer', () => {
         expect(textArea.classList.contains('pm-disabled')).to.eq(false);
         expect(textLayer.pm.hasFocus()).to.eq(true);
         textLayer.pm.blur();
+        expect(textLayer.pm.hasFocus()).to.eq(false);
+
+        textLayer.pm.disable();
         expect(textArea.readOnly).to.eq(true);
         expect(textArea.classList.contains('pm-disabled')).to.eq(true);
-        expect(textLayer.pm.hasFocus()).to.eq(false);
       });
     });
     it('getElement', () => {
@@ -403,6 +409,8 @@ describe('Text Layer', () => {
           textMarker: true,
           text: '',
         }).addTo(map);
+        textLayer.pm.enable();
+        textLayer.pm.focus();
 
         textLayer.on('pm:textchange', (e) => {
           event = e.type;

--- a/src/js/Edit/L.PM.Edit.Text.js
+++ b/src/js/Edit/L.PM.Edit.Text.js
@@ -245,7 +245,7 @@ Edit.Text = Edit.extend({
 
     this._autoResize();
 
-    if (enable) {
+    if (enable === true) {
       // enable editing for the marker
       this.enable();
       this.focus();


### PR DESCRIPTION
Disable autofocus for new added Text-Layers

```
L.marker(map.getCenter(), {textMarker: true, text: 'Test21'}).addTo(map);
```

Old:
![focus-marker-old](https://user-images.githubusercontent.com/19800037/197343920-41914ce9-d098-47dd-ae07-7f44d0509550.gif)

New:
![focus-marker-new](https://user-images.githubusercontent.com/19800037/197343923-f7aece0a-686c-4d64-9837-2a3ba3e37ec4.gif)
