### PR TITLE
Doesn't return rotation help-layer over getGeomanLayers()

### DIFF
--- a/cypress/integration/rotation.spec.js
+++ b/cypress/integration/rotation.spec.js
@@ -220,4 +220,17 @@ describe('Rotation', () => {
       }).to.not.throw();
     });
   });
+
+  it('doesn\'t return the rotation help-layer over getGeomanLayers()', () => {
+    cy.window().then(({ map, L }) => {
+      const coords = [
+        [1, 2],
+        [3, 4],
+      ];
+      const rect = L.rectangle(coords).addTo(map);
+      rect.pm.enableRotate();
+
+      expect(map.pm.getGeomanLayers().length).to.eq(1);
+    });
+  });
 });

--- a/src/js/Mixins/Rotating.js
+++ b/src/js/Mixins/Rotating.js
@@ -167,6 +167,7 @@ const RotateMixin = {
     });
     // we connect the temp polygon (that will be enabled for rotation) with the current layer, so that we can rotate the current layer too
     this._rotatePoly.pm._rotationLayer = this._layer;
+    this._rotatePoly._pmTempLayer = true;
     this._rotatePoly.pm.enable();
 
     // store the original latlngs


### PR DESCRIPTION
`map.pm.getGeomanLayers()` returned the helper layer too
Fixes #1285