### PR TITLE
fix: Draw.Rectangle should use the same code to get the corners as Edit.Rectangle

### DIFF
--- a/cypress/integration/rectangle.spec.js
+++ b/cypress/integration/rectangle.spec.js
@@ -880,4 +880,26 @@ describe('Draw Rectangle', () => {
       expect(layer.options.color).to.eql('red');
     });
   });
+
+  it('Return correct corners of rotated rectangle while drawing', () => {
+    cy.window().then(({ map }) => {
+      map.pm.setGlobalOptions({ rectangleAngle: 45 });
+    });
+
+    cy.toolbarButton('rectangle')
+      .click()
+      .closest('.button-container')
+      .should('have.class', 'active');
+
+    cy.get(mapSelector).click(220, 220);
+    cy.get(mapSelector).trigger('mousemove', 500, 300);
+
+    cy.window().then(({ map }) => {
+      const corners = map.pm.Draw.Rectangle._findCorners();
+      expect(corners[0].equals([51.50820824957313, -0.13801574707031253])).to.eql(true);
+      expect(corners[1].equals([51.48897254548231, -0.10711669921875001])).to.eql(true);
+      expect(corners[2].equals([51.499660050014434, -0.08995056152343751])).to.eql(true);
+      expect(corners[3].equals([51.51889124411909, -0.12084960937500001])).to.eql(true);
+    });
+  });
 });

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -246,13 +246,13 @@ Draw.Rectangle = Draw.extend({
     }
   },
   _findCorners() {
-    const latlngs = this._layer.getLatLngs()[0]; 
-    return L.PM.Utils._getRotatedRectangle( 
-       latlngs[0], 
-       latlngs[2], 
-       this._angle || 0, 
-       this._map 
-   ); 
+    const latlngs = this._layer.getLatLngs()[0];
+    return L.PM.Utils._getRotatedRectangle(
+       latlngs[0],
+       latlngs[2],
+      this.options.rectangleAngle || 0,
+       this._map
+   );
   },
   _finishShape(e) {
     // assign the coordinate of the click to the hintMarker, that's necessary for

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -246,14 +246,13 @@ Draw.Rectangle = Draw.extend({
     }
   },
   _findCorners() {
-    const corners = this._layer.getBounds();
-
-    const northwest = corners.getNorthWest();
-    const northeast = corners.getNorthEast();
-    const southeast = corners.getSouthEast();
-    const southwest = corners.getSouthWest();
-
-    return [northwest, northeast, southeast, southwest];
+    const latlngs = this._layer.getLatLngs()[0]; 
+    return L.PM.Utils._getRotatedRectangle( 
+       latlngs[0], 
+       latlngs[2], 
+       this._angle || 0, 
+       this._map 
+   ); 
   },
   _finishShape(e) {
     // assign the coordinate of the click to the hintMarker, that's necessary for

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -32,6 +32,7 @@ const Draw = L.Class.extend({
     continueDrawing: false,
     snapSegment: true,
     requireSnapToFinish: false,
+    rectangleAngle: 0
   },
   setOptions(options) {
     L.Util.setOptions(this, options);


### PR DESCRIPTION
### What does this PR do

Followed two steps as mentioned in the issue.

- [x] Update _findCorners in Draw.Rectangle
- [x] add rectangleAngle: 0 to the default Draw options: src/js/Draw/L.PM.Draw.js

Fixed Draw.Rectangle file in [leaflet-geoman/src/js/Draw/L.PM.Draw.Rectangle.js](https://github.com/geoman-io/leaflet-geoman/blob/932d4a986ec5853f183a1a69fa8d9d55bff963de/src/js/Draw/L.PM.Draw.Rectangle.js#L248-L257)

Issue Number- #1369 