### PR TITLE
Remove `autofocus` from Text Layer

### DIFF
--- a/src/js/Draw/L.PM.Draw.Text.js
+++ b/src/js/Draw/L.PM.Draw.Text.js
@@ -183,7 +183,6 @@ Draw.Text = Draw.extend({
 
   _createTextArea() {
     const textArea = document.createElement('textarea');
-    textArea.autofocus = true;
     textArea.readOnly = true;
     textArea.classList.add('pm-textarea', 'pm-disabled');
     return textArea;


### PR DESCRIPTION
`autofocus` was wrongly added as a property to the textarea for the Text Layer. 

The purpose of `autofocus` is to get the focus on the page load but this is clearly nothing that Geoman wants to do.

Fixes: #1399, #1404