### PR TITLE
Update GlobalModes for Removal and Rotate + some little fixes

### DIFF
--- a/cypress/integration/globalmodes.spec.js
+++ b/cypress/integration/globalmodes.spec.js
@@ -255,7 +255,7 @@ describe('Modes', () => {
     cy.testLayerAdditionPerformance();
   });
 
-  it('Test removal when preventMarkerRremoval is passed to global options', () => {
+  it('Test removal when preventMarkerRemoval is passed to global options', () => {
     cy.toolbarButton('rectangle')
       .click()
       .closest('.button-container')
@@ -346,6 +346,83 @@ describe('Modes', () => {
     cy.window().then(({ map }) => {
       expect(map.pm.getGeomanLayers()[0].pm.layerDragEnabled()).to.equal(true);
       expect(map.pm.getGeomanLayers()[1].pm.layerDragEnabled()).to.equal(true);
+    });
+  });
+
+  it('re-applies rotate mode onAdd for first layer', (done) => {
+    cy.toolbarButton('rotate').click();
+
+    cy.window().then(({ map, L }) => {
+      const jsonString =
+        '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.155182,51.515687],[-0.155182,51.521028],[-0.124283,51.521028],[-0.124283,51.510345],[-0.155182,51.515687]]]}}';
+      const poly = JSON.parse(jsonString);
+      L.geoJSON(poly).addTo(map);
+    });
+
+    cy.window().then(({ map }) => {
+      setTimeout(() => {
+        expect(map.pm.getGeomanLayers()[0].pm.rotateEnabled()).to.equal(true);
+        done();
+      }, 100);
+    });
+  });
+
+  it('re-applies edit mode onAdd for first layer', (done) => {
+    cy.toolbarButton('edit').click();
+
+    cy.window().then(({ map, L }) => {
+      const jsonString =
+        '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.155182,51.515687],[-0.155182,51.521028],[-0.124283,51.521028],[-0.124283,51.510345],[-0.155182,51.515687]]]}}';
+      const poly = JSON.parse(jsonString);
+      L.geoJSON(poly).addTo(map);
+    });
+
+    cy.window().then(({ map }) => {
+      setTimeout(() => {
+        expect(map.pm.getGeomanLayers()[0].pm.enabled()).to.equal(true);
+        done();
+      }, 100);
+    });
+  });
+
+  it('re-applies move mode onAdd for first layer', (done) => {
+    cy.toolbarButton('drag').click();
+
+    cy.window().then(({ map, L }) => {
+      const jsonString =
+        '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.155182,51.515687],[-0.155182,51.521028],[-0.124283,51.521028],[-0.124283,51.510345],[-0.155182,51.515687]]]}}';
+      const poly = JSON.parse(jsonString);
+      L.geoJSON(poly).addTo(map);
+    });
+
+    cy.window().then(({ map }) => {
+      setTimeout(() => {
+        expect(map.pm.getGeomanLayers()[0].pm.layerDragEnabled()).to.equal(
+          true
+        );
+        done();
+      }, 100);
+    });
+  });
+
+  it('re-applies removal mode onAdd for first layer', (done) => {
+    cy.toolbarButton('delete').click();
+
+    cy.window().then(({ map, L }) => {
+      const jsonString =
+        '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.155182,51.515687],[-0.155182,51.521028],[-0.124283,51.521028],[-0.124283,51.510345],[-0.155182,51.515687]]]}}';
+      const poly = JSON.parse(jsonString);
+      L.geoJSON(poly).addTo(map);
+    });
+
+    cy.window().then(({ map }) => {
+      setTimeout(() => {
+        const layer = map.pm.getGeomanLayers()[0];
+        expect(layer.listens('click', map.pm.removeLayer, map.pm)).to.equal(
+          true
+        );
+        done();
+      }, 100);
     });
   });
 });

--- a/src/js/Mixins/Modes/Mode.Drag.js
+++ b/src/js/Mixins/Modes/Mode.Drag.js
@@ -7,7 +7,9 @@ const GlobalDragMode = {
     this._addedLayersDrag = {};
 
     layers.forEach((layer) => {
-      layer.pm.enableLayerDrag();
+      if (this._isRelevantForDrag(layer)) {
+        layer.pm.enableLayerDrag();
+      }
     });
 
     if (!this.throttledReInitDrag) {
@@ -58,11 +60,11 @@ const GlobalDragMode = {
   reinitGlobalDragMode() {
     const layers = this._addedLayersDrag;
     this._addedLayersDrag = {};
-    for (const id in layers) {
-      const layer = layers[id];
+    if (this.globalDragModeEnabled()) {
+      for (const id in layers) {
+        const layer = layers[id];
 
-      if (this._isRelevantForDrag(layer)) {
-        if (this.globalDragModeEnabled()) {
+        if (this._isRelevantForDrag(layer)) {
           layer.pm.enableLayerDrag();
         }
       }

--- a/src/js/Mixins/Modes/Mode.Edit.js
+++ b/src/js/Mixins/Modes/Mode.Edit.js
@@ -16,7 +16,9 @@ const GlobalEditMode = {
 
     // enable all layers
     layers.forEach((layer) => {
-      layer.pm.enable(options);
+      if (this._isRelevantForEdit(layer)) {
+        layer.pm.enable(options);
+      }
     });
 
     if (!this.throttledReInitEdit) {
@@ -27,9 +29,9 @@ const GlobalEditMode = {
       );
     }
 
-    // save the added layers into the _addedLayers array, to read it later out
-    this._addedLayers = {};
-    this.map.on('layeradd', this._layerAdded, this);
+    // save the added layers into the _addedLayersEdit array, to read it later out
+    this._addedLayersEdit = {};
+    this.map.on('layeradd', this._layerAddedEdit, this);
     // handle layers that are added while in edit mode
     this.map.on('layeradd', this.throttledReInitEdit, this);
 
@@ -49,6 +51,7 @@ const GlobalEditMode = {
     });
 
     // cleanup layer off event
+    this.map.off('layeradd', this._layerAddedEdit, this);
     this.map.off('layeradd', this.throttledReInitEdit, this);
 
     // Set toolbar button to currect status
@@ -75,22 +78,22 @@ const GlobalEditMode = {
     }
   },
   handleLayerAdditionInGlobalEditMode() {
-    const layers = this._addedLayers;
-    this._addedLayers = {};
-    for (const id in layers) {
-      const layer = layers[id];
-      // when global edit mode is enabled and a layer is added to the map,
-      // enable edit for that layer if it's relevant
+    const layers = this._addedLayersEdit;
+    this._addedLayersEdit = {};
+    if (this.globalEditModeEnabled()) {
+      for (const id in layers) {
+        const layer = layers[id];
+        // when global edit mode is enabled and a layer is added to the map,
+        // enable edit for that layer if it's relevant
 
-      if (this._isRelevantForEdit(layer)) {
-        if (this.globalEditModeEnabled()) {
+        if (this._isRelevantForEdit(layer)) {
           layer.pm.enable({ ...this.globalOptions });
         }
       }
     }
   },
-  _layerAdded({ layer }) {
-    this._addedLayers[L.stamp(layer)] = layer;
+  _layerAddedEdit({ layer }) {
+    this._addedLayersEdit[L.stamp(layer)] = layer;
   },
   _isRelevantForEdit(layer) {
     return (

--- a/src/js/Mixins/Modes/Mode.Rotate.js
+++ b/src/js/Mixins/Modes/Mode.Rotate.js
@@ -13,12 +13,15 @@ const GlobalRotateMode = {
 
     if (!this.throttledReInitRotate) {
       this.throttledReInitRotate = L.Util.throttle(
-        this._reinitGlobalRotateMode,
+        this.handleLayerAdditionInGlobalRotateMode,
         100,
         this
       );
     }
+
+    this._addedLayersRotate = {};
     // handle layers that are added while in rotate mode
+    this.map.on('layeradd', this._layerAddedRotate, this);
     this.map.on('layeradd', this.throttledReInitRotate, this);
 
     // toogle the button in the toolbar if this is called programatically
@@ -35,6 +38,7 @@ const GlobalRotateMode = {
     });
 
     // remove map handler
+    this.map.off('layeradd', this._layerAddedRotate, this);
     this.map.off('layeradd', this.throttledReInitRotate, this);
 
     // toogle the button in the toolbar if this is called programatically
@@ -51,27 +55,31 @@ const GlobalRotateMode = {
       this.enableGlobalRotateMode();
     }
   },
-  _reinitGlobalRotateMode({ layer }) {
-    // do nothing if layer is not handled by leaflet so it doesn't fire unnecessarily
-    if (!this._isRelevantForRotate(layer)) {
-      return;
-    }
-
-    // re-enable global rotation mode if it's enabled already
-    if (this.globalRotateModeEnabled()) {
-      this.disableGlobalRotateMode();
-      this.enableGlobalRotateMode();
-    }
-  },
   _isRelevantForRotate(layer) {
     return (
       layer.pm &&
+      layer instanceof L.Polyline &&
       !(layer instanceof L.LayerGroup) &&
       ((!L.PM.optIn && !layer.options.pmIgnore) || // if optIn is not set / true and pmIgnore is not set / true (default)
         (L.PM.optIn && layer.options.pmIgnore === false)) && // if optIn is true and pmIgnore is false
       !layer._pmTempLayer &&
       layer.pm.options.allowRotation
     );
+  },
+  handleLayerAdditionInGlobalRotateMode() {
+    const layers = this._addedLayersRotate;
+    this._addedLayersRotate = {};
+    if (this.globalRotateModeEnabled()) {
+      for (const id in layers) {
+        const layer = layers[id];
+        if (this._isRelevantForRemoval(layer)) {
+          layer.pm.enableRotate();
+        }
+      }
+    }
+  },
+  _layerAddedRotate({ layer }) {
+    this._addedLayersRotate[L.stamp(layer)] = layer;
   },
 };
 export default GlobalRotateMode;


### PR DESCRIPTION
Fixes: #1412

Global Rotate and Global Removal was not working if the first layer on the map was added **after** enabling the mode.

A second issue was that for each new added layer the events `pm:globalrotatemodetoggled` or `pm:globalremovalmodetoggled` were fired.