### PR TITLE
After disabling & enabling of button, don't call disable on the draw layer. 

### DIFF
--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -501,7 +501,7 @@ describe('Testing the Toolbar', () => {
       });
   });
 
-  it("After disabling & enabling of button, while a mode is active, don't call disable on the draw layer", (done) => {
+  it("After disabling & enabling of a button, while a mode is active, don't call disable on the draw layer", (done) => {
     let eventFired = '';
 
     cy.toolbarButton('edit').click();

--- a/cypress/integration/toolbar.spec.js
+++ b/cypress/integration/toolbar.spec.js
@@ -500,4 +500,24 @@ describe('Testing the Toolbar', () => {
         expect(eventFired).to.equal('drawPolygon');
       });
   });
+
+  it("After disabling & enabling of button, while a mode is active, don't call disable on the draw layer", (done) => {
+    let eventFired = '';
+
+    cy.toolbarButton('edit').click();
+
+    cy.window().then(({ map }) => {
+      map.on('pm:drawend', ({ shape }) => {
+        eventFired = shape;
+      });
+      map.pm.Toolbar.setButtonDisabled('drawText', true);
+      map.pm.Toolbar.setButtonDisabled('drawText', false);
+    });
+    cy.toolbarButton('text').click();
+
+    cy.window().then(() => {
+      expect(eventFired).to.equal('');
+      done();
+    });
+  });
 });

--- a/src/js/Draw/L.PM.Draw.Text.js
+++ b/src/js/Draw/L.PM.Draw.Text.js
@@ -74,7 +74,7 @@ Draw.Text = Draw.extend({
     this._map.off('click', this._createMarker, this);
 
     // remove hint marker
-    this._hintMarker.remove();
+    this._hintMarker?.remove();
 
     this._map.getContainer().classList.remove('geoman-draw-cursor');
 

--- a/src/js/Toolbar/L.Controls.js
+++ b/src/js/Toolbar/L.Controls.js
@@ -239,6 +239,9 @@ const PMButton = L.Control.extend({
   },
 
   _onBtnClick() {
+    if (this._button.disabled) {
+      return;
+    }
     if (this._button.disableOtherButtons) {
       this._map.pm.Toolbar.triggerClickOnToggledButtons(this);
     }
@@ -270,13 +273,9 @@ const PMButton = L.Control.extend({
     if (this._button.disabled) {
       L.DomUtil.addClass(button, className);
       button.setAttribute('aria-disabled', 'true');
-      L.DomEvent.off(button, 'click', this._triggerClick, this);
-      L.DomEvent.off(button, 'click', this._onBtnClick, this);
     } else {
       L.DomUtil.removeClass(button, className);
       button.setAttribute('aria-disabled', 'false');
-      L.DomEvent.on(button, 'click', this._triggerClick, this);
-      L.DomEvent.on(button, 'click', this._onBtnClick, this);
     }
   },
 });


### PR DESCRIPTION
After disabling & enabling of button, while a mode is active, don't call disable on the draw layer.
And added that text disable is not throwing an error if hintMarker is not set.

Fixes: #1422