### PR TITLE
fix global keyboard and window listeners are not removed after the map is destroyed

### DIFF
--- a/cypress/integration/mixins.spec.js
+++ b/cypress/integration/mixins.spec.js
@@ -1,5 +1,5 @@
-describe('Should unbind event listeners that bound by the Mixins after the map is destroyed', () => {
-  it('KeyboardMixin', () => {
+describe('', (KeyboardMixin) => {
+  it('Should unbind event listeners that bound by the KeyboardMixin after the map is destroyed', () => {
     cy.window().then((window) => {
       const { map, document } = window;
 

--- a/cypress/integration/mixins.spec.js
+++ b/cypress/integration/mixins.spec.js
@@ -1,0 +1,25 @@
+describe('Should unbind event listeners that bound by the Mixins after the map is destroyed', () => {
+  it('KeyboardMixin', () => {
+    cy.window().then((window) => {
+      const { map, document } = window;
+
+      map.remove();
+
+      const isWindowBlurEventUnbound = !Object.entries(
+        window._leaflet_events
+      ).some(([name, handler]) => name.startsWith('blur') && handler);
+      expect(
+        isWindowBlurEventUnbound,
+        'window blur event listener is not unbound'
+      ).to.eq(true);
+
+      const isKeyUpDownEventUnbound = !Object.entries(
+        document._leaflet_events
+      ).some(([name, handler]) => name.startsWith('key') && handler);
+      expect(
+        isKeyUpDownEventUnbound,
+        'document keyboard event listener is not unbound'
+      ).to.eq(true);
+    });
+  });
+});

--- a/cypress/integration/mixins.spec.js
+++ b/cypress/integration/mixins.spec.js
@@ -1,4 +1,4 @@
-describe('', (KeyboardMixin) => {
+describe('KeyboardMixin', () => {
   it('Should unbind event listeners that bound by the KeyboardMixin after the map is destroyed', () => {
     cy.window().then((window) => {
       const { map, document } = window;

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -5,7 +5,7 @@ import GlobalDragMode from './Mixins/Modes/Mode.Drag';
 import GlobalRemovalMode from './Mixins/Modes/Mode.Removal';
 import GlobalRotateMode from './Mixins/Modes/Mode.Rotate';
 import EventMixin from './Mixins/Events';
-import KeyboardMixins from './Mixins/Keyboard';
+import createKeyboardMixins from './Mixins/Keyboard';
 import { getRenderer } from './helpers';
 
 const Map = L.Class.extend({
@@ -20,7 +20,7 @@ const Map = L.Class.extend({
     this.map = map;
     this.Draw = new L.PM.Draw(map);
     this.Toolbar = new L.PM.Toolbar(map);
-    this.Keyboard = KeyboardMixins;
+    this.Keyboard = createKeyboardMixins();
 
     this.globalOptions = {
       snappable: true,

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -7,7 +7,7 @@ const createKeyboardMixins = () => ({
     L.DomEvent.on(document, 'keydown keyup', this._onKeyListener, this);
     L.DomEvent.on(window, 'blur', this._onBlur, this);
     // clean up global listeners when current map instance is destroyed
-    map.once('unload', this_unbindKeyListenerEvents, this);
+    map.once('unload', this._unbindKeyListenerEvents, this);
   },
   _unbindKeyListenerEvents() {
       L.DomEvent.off(document, 'keydown keyup', this._onKeyListener, this);

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -1,9 +1,16 @@
-const KeyboardMixins = {
+// use function to create a new mixin object for keeping isolation
+// to make it work for multiple map instances
+const createKeyboardMixins = () => ({
   _lastEvents: { keydown: undefined, keyup: undefined, current: undefined },
   _initKeyListener(map) {
     this.map = map;
     L.DomEvent.on(document, 'keydown keyup', this._onKeyListener, this);
     L.DomEvent.on(window, 'blur', this._onBlur, this);
+    // clean up global listeners when current map instance is destroyed
+    map.on('unload', () => {
+      L.DomEvent.off(document, 'keydown keyup', this._onKeyListener, this);
+      L.DomEvent.off(window, 'blur', this._onBlur, this);
+    });
   },
   _onKeyListener(e) {
     let focusOn = 'document';
@@ -44,6 +51,6 @@ const KeyboardMixins = {
   getPressedKey() {
     return this._lastEvents.current?.event.key;
   },
-};
+});
 
-export default KeyboardMixins;
+export default createKeyboardMixins;

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -7,10 +7,11 @@ const createKeyboardMixins = () => ({
     L.DomEvent.on(document, 'keydown keyup', this._onKeyListener, this);
     L.DomEvent.on(window, 'blur', this._onBlur, this);
     // clean up global listeners when current map instance is destroyed
-    map.on('unload', () => {
+    map.once('unload', this_unbindKeyListenerEvents, this);
+  },
+  _unbindKeyListenerEvents() {
       L.DomEvent.off(document, 'keydown keyup', this._onKeyListener, this);
       L.DomEvent.off(window, 'blur', this._onBlur, this);
-    });
   },
   _onKeyListener(e) {
     let focusOn = 'document';


### PR DESCRIPTION
Hi,

I noticed the global listeners bound in the keyboard mixin were not unbound after the map was destroyed, which makes the listener always exist and makes the code throw errors even if the component is destroyed in those single-page applications.

So I think we should unbind the listeners somewhere after destroying the map. I currently put this logic into the `_initKeyListener` function of the `Keyboard` mixin. Also, to keep the isolation of the mixin, I changed the singleton Keyboard mixin object to a function that returns a new object at each call to make it work for multiple map instances, or the entire listener will be removed as long as one map is destroyed, which causes the event listener for other maps to not work.

To reproduce,

- https://codepen.io/plainheart/pen/bGZVxgv
- Or just open `demo/index.html` in this project and call `map.remove()`