### PR TITLE
Minor: Force rotateEnabled() to always return a boolean.

### DIFF
--- a/cypress/integration/rotation.spec.js
+++ b/cypress/integration/rotation.spec.js
@@ -37,6 +37,7 @@ describe('Rotation', () => {
 
     cy.window().then(({ map }) => {
       const layer = map.pm.getGeomanDrawLayers()[0];
+      expect(layer.pm.rotateEnabled()).to.equal(false);
 
       layer.pm.enableRotate();
       expect(layer.pm.rotateEnabled()).to.equal(true);

--- a/src/js/Mixins/Rotating.js
+++ b/src/js/Mixins/Rotating.js
@@ -222,7 +222,7 @@ const RotateMixin = {
     }
   },
   rotateEnabled() {
-    return this._rotateEnabled;
+    return !!this._rotateEnabled;
   },
   // angle is clockwise (0-360)
   rotateLayer(degrees) {


### PR DESCRIPTION
`_rotateEnabled` might not yet be initialized when calling `rotateEnabled`, returning `undefined` in that case:

https://github.com/geoman-io/leaflet-geoman/blob/7f388cc15ee5b7047bd997475ccaa7d30c7d15f0/src/js/Mixins/Rotating.js#L225

Hence converting to boolean first. Adopting this pattern from other places such as `layerDragEnabled`:

https://github.com/geoman-io/leaflet-geoman/blob/7f388cc15ee5b7047bd997475ccaa7d30c7d15f0/src/js/Mixins/Dragging.js#L133