### PR TITLE
Suppress errors in Snapping.js

### DIFF
--- a/src/js/Mixins/Snapping.js
+++ b/src/js/Mixins/Snapping.js
@@ -258,7 +258,7 @@ const SnapMixin = {
     this.debugIndicatorLines = debugIndicatorLines;
   },
   _handleSnapLayerRemoval({ layer }) {
-    if (!layer._leaflet_id) {
+    if (!layer._leaflet_id || !this._snapList) {
       return;
     }
     // find the layers index in snaplist


### PR DESCRIPTION
On mouse-over, markers, L.Divicons or sometimes layer groups, 
with a tool active, 
I get errors in console where this._snapList is undefined.

It originates from events dispatched from Leaflet when tooltips are opened/closed. 

This error sometimes breaks Geoman and I have to reload the page to continue.

A simple solution is to check the _snapList property.

This non-breaking change, solves the problem.