### PR TITLE
fix: Make sure text layer's text is center

### DIFF
--- a/src/css/layers.css
+++ b/src/css/layers.css
@@ -54,6 +54,7 @@
 }
 
 .pm-textarea {
+  box-sizing: content-box;
   background-color: #fff;
   color: #000;
   resize: none;


### PR DESCRIPTION
The text in the text layer needs to be centered with the textarea in `box-sizing: content-box`.
This is the [offical website demo](https://geoman.io/demo) text layer.

![image](https://github.com/user-attachments/assets/893f5681-8582-4a46-9947-c5c86a578310)

This is the text layer located in `box-sizing: content-box`.

![image](https://github.com/user-attachments/assets/7188b7c0-0801-4db6-80cc-20aad3b666ca)
