### PR TITLE
Fix missing type definition

### DIFF
--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -707,6 +707,7 @@ declare module 'leaflet' {
       text: string;
       onClick?: (e: any) => void;
       title?: string;
+      name?: string;
     }
 
     type TOOLBAR_CONTROL_ORDER =


### PR DESCRIPTION
Fixed missing type definition for the "name" property of the Action object, which is used as the class name for the button.  

Source:
https://github.com/geoman-io/leaflet-geoman/blob/9f6aac717f2909fbc12467b7e1dca6ec091b2fd3/src/js/Toolbar/L.Controls.js#L163-L176   

TS error:


![image](https://github.com/user-attachments/assets/6903d654-70be-4a36-aae8-f57712709a9d)
