### PR TITLE
Doi mayank/fix custom props #1111

### DIFF
--- a/cypress/integration/circle.spec.js
+++ b/cypress/integration/circle.spec.js
@@ -348,10 +348,10 @@ describe('Draw Circle', () => {
     });
   });
 
-  it('creates circles (non-resizableCircle)', () => {
+  it('creates circles (non-resizeableCircle)', () => {
     cy.window().then(({ map }) => {
       map.pm.setGlobalOptions({
-        resizableCircle: false,
+        resizeableCircle: false,
         continueDrawing: true,
       });
     });
@@ -373,9 +373,9 @@ describe('Draw Circle', () => {
     cy.hasCircleLayers(3);
   });
 
-  it('disable dragging correctly (non-resizableCircle)', () => {
+  it('disable dragging correctly (non-resizeableCircle)', () => {
     cy.window().then(({ map }) => {
-      map.pm.setGlobalOptions({ resizableCircle: false });
+      map.pm.setGlobalOptions({ resizeableCircle: false });
     });
 
     cy.toolbarButton('circle')
@@ -397,9 +397,9 @@ describe('Draw Circle', () => {
     });
   });
 
-  it('deletes no circles by right-click (non-resizableCircle)', () => {
+  it('deletes no circles by right-click (non-resizeableCircle)', () => {
     cy.window().then(({ map }) => {
-      map.pm.setGlobalOptions({ resizableCircle: false });
+      map.pm.setGlobalOptions({ resizeableCircle: false });
     });
 
     cy.toolbarButton('circle')
@@ -421,9 +421,9 @@ describe('Draw Circle', () => {
     cy.hasCircleLayers(1);
   });
 
-  it('change color of circleMarker while drawing (non-resizableCircle)', () => {
+  it('change color of circleMarker while drawing (non-resizeableCircle)', () => {
     cy.window().then(({ map }) => {
-      map.pm.setGlobalOptions({ resizableCircle: false });
+      map.pm.setGlobalOptions({ resizeableCircle: false });
     });
 
     cy.toolbarButton('circle')

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1776,10 +1776,15 @@ declare module 'leaflet' {
     /**
      * ROTATE MODE MAP EVENT HANDLERS
      */
-    export type GlobalRotateModeToggledEventHandler = (e: {
+    export type BaseEventHandler = (e: { 
+      source: any; 
+      custom?: Record<string, any>; 
+   }) => void;
+
+    export type GlobalRotateModeToggledEventHandler = BaseEventHandler & {
       enabled: boolean;
       map: L.Map;
-    }) => void;
+  };
 
     /**
      * UNION MODE MAP EVENT HANDLERS

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1297,7 +1297,7 @@ declare module 'leaflet' {
       editable?: boolean;
 
       /** Enables radius editing while drawing a Circle (default:true). */
-      resizableCircle?: boolean;
+      resizeableCircle?: boolean;
 
       /** Enables radius editing while drawing a CircleMarker (default:false). */
       resizeableCircleMarker?: boolean;

--- a/src/js/Draw/L.PM.Draw.Circle.js
+++ b/src/js/Draw/L.PM.Draw.Circle.js
@@ -8,7 +8,7 @@ Draw.Circle = Draw.CircleMarker.extend({
     this._BaseCircleClass = L.Circle;
     this._minRadiusOption = 'minRadiusCircle';
     this._maxRadiusOption = 'maxRadiusCircle';
-    this._editableOption = 'resizableCircle';
+    this._editableOption = 'resizeableCircle';
     this._defaultRadius = 100;
   },
   _extendingEnable() {},

--- a/src/js/Draw/L.PM.Draw.js
+++ b/src/js/Draw/L.PM.Draw.js
@@ -28,7 +28,7 @@ const Draw = L.Class.extend({
     minRadiusCircleMarker: null,
     maxRadiusCircleMarker: null,
     resizeableCircleMarker: false,
-    resizableCircle: true,
+    resizeableCircle: true,
     markerEditable: true,
     continueDrawing: false,
     snapSegment: true,

--- a/src/js/Edit/L.PM.Edit.Circle.js
+++ b/src/js/Edit/L.PM.Edit.Circle.js
@@ -8,7 +8,7 @@ Edit.Circle = Edit.CircleMarker.extend({
 
     this._minRadiusOption = 'minRadiusCircle';
     this._maxRadiusOption = 'maxRadiusCircle';
-    this._editableOption = 'resizableCircle';
+    this._editableOption = 'resizeableCircle';
     // create polygon around the circle border
     this._updateHiddenPolyCircle();
   },

--- a/src/js/Edit/L.PM.Edit.js
+++ b/src/js/Edit/L.PM.Edit.js
@@ -27,7 +27,7 @@ const Edit = L.Class.extend({
     addVertexValidation: undefined,
     moveVertexValidation: undefined,
     resizeableCircleMarker: false,
-    resizableCircle: true,
+    resizeableCircle: true,
   },
   setOptions(options) {
     L.Util.setOptions(this, options);

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -152,8 +152,8 @@ const Map = L.Class.extend({
     let reenableCircle = false;
     if (
       this.map.pm.Draw.Circle.enabled() &&
-      !!this.map.pm.Draw.Circle.options.resizableCircle !==
-        !!options.resizableCircle
+      !!this.map.pm.Draw.Circle.options.resizeableCircle !==
+        !!options.resizeableCircle
     ) {
       this.map.pm.Draw.Circle.disable();
       reenableCircle = true;

--- a/src/js/Mixins/Dragging.js
+++ b/src/js/Mixins/Dragging.js
@@ -198,7 +198,7 @@ const DragMixin = {
     if (this._layer instanceof L.CircleMarker) {
       let _editableOption = 'resizeableCircleMarker';
       if (this._layer instanceof L.Circle) {
-        _editableOption = 'resizableCircle';
+        _editableOption = 'resizeableCircle';
       }
 
       if (this.options.snappable && !fromLayerSync && !layersToSyncFound) {
@@ -369,7 +369,7 @@ const DragMixin = {
 
     if (
       (this._layer instanceof L.Circle &&
-        this._layer.options.resizableCircle) ||
+        this._layer.options.resizeableCircle) ||
       (this._layer instanceof L.CircleMarker &&
         this._layer.options.resizeableCircleMarker)
     ) {

--- a/src/js/Mixins/Events.js
+++ b/src/js/Mixins/Events.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+// import merge from 'lodash/merge';
 
 const EventMixin = {
   // Draw Events
@@ -698,7 +698,7 @@ const EventMixin = {
 
   // private (very private) fire function
   __fire(fireLayer, type, payload, source, customPayload = {}) {
-    payload = merge(payload, customPayload, { source });
+    payload = { ...payload, ...customPayload, source };
     L.PM.Utils._fireEvent(fireLayer, type, payload);
   },
 };

--- a/src/js/Mixins/Events.js
+++ b/src/js/Mixins/Events.js
@@ -1,4 +1,4 @@
-// import merge from 'lodash/merge';
+import merge from 'lodash/merge';
 
 const EventMixin = {
   // Draw Events
@@ -698,7 +698,7 @@ const EventMixin = {
 
   // private (very private) fire function
   __fire(fireLayer, type, payload, source, customPayload = {}) {
-    payload = { ...payload, ...customPayload, source };
+    payload = merge({}, payload, customPayload, { source });
     L.PM.Utils._fireEvent(fireLayer, type, payload);
   },
 };


### PR DESCRIPTION
#1111 TypeScript EventHandlers do not support all properties in payload

- Created a BaseEventType with source and custom properties.
- Extended event-specific types from the base type to ensure consistency.
- Updated the _fire method in Events.js to merge custom payload with source.