### PR TITLE
Prevent the creation of an additional Marker when dragging a Marker i…

### DIFF
--- a/cypress/e2e/marker.cy.js
+++ b/cypress/e2e/marker.cy.js
@@ -317,27 +317,31 @@ describe('Draw Marker', () => {
     });
   });
 
-  it('drag in draw mode does not create additional marker', (done) => {
+  it('does not create additional marker while dragging in draw mode ', () => {
     cy.toolbarButton('marker').click();
 
     cy.get(mapSelector).click(150, 250);
-    cy.wait(1000);
 
     cy.window().then(({ map }) => {
       expect(map.pm.getGeomanDrawLayers().length).to.eq(1);
     });
 
-    cy.get(mapSelector).trigger('mousemove', 150, 230);
-    cy.get(mapSelector).trigger('mouseover', 150, 230, { which: 1 });
     cy.get(mapSelector).trigger('mousedown', 150, 230, { which: 1 });
     cy.get(mapSelector).trigger('mousemove', 170, 290, { which: 1 });
+    // Do not create a new marker while dragging
     cy.get(mapSelector).click(170, 290);
-    cy.get(mapSelector).trigger('mouseup', 170, 290, { which: 1, force: true });
+    cy.get(mapSelector).trigger('mouseup', 170, 290, { which: 1 });
     cy.get(mapSelector).trigger('mousemove', 190, 340, { which: 1 });
 
     cy.window().then(({ map }) => {
       expect(map.pm.getGeomanDrawLayers().length).to.eq(1);
-      done();
+    });
+
+    // Create a new marker after dragging with clicking on the icon of a marker
+    cy.get(mapSelector).click(170, 290);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.getGeomanDrawLayers().length).to.eq(2);
     });
   });
 });

--- a/cypress/e2e/marker.cy.js
+++ b/cypress/e2e/marker.cy.js
@@ -316,4 +316,28 @@ describe('Draw Marker', () => {
       expect(layer._icon.src.endsWith('someIcon.png')).to.eql(true);
     });
   });
+
+  it('drag in draw mode does not create additional marker', (done) => {
+    cy.toolbarButton('marker').click();
+
+    cy.get(mapSelector).click(150, 250);
+    cy.wait(1000);
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.getGeomanDrawLayers().length).to.eq(1);
+    });
+
+    cy.get(mapSelector).trigger('mousemove', 150, 230);
+    cy.get(mapSelector).trigger('mouseover', 150, 230, { which: 1 });
+    cy.get(mapSelector).trigger('mousedown', 150, 230, { which: 1 });
+    cy.get(mapSelector).trigger('mousemove', 170, 290, { which: 1 });
+    cy.get(mapSelector).click(170, 290);
+    cy.get(mapSelector).trigger('mouseup', 170, 290, { which: 1, force: true });
+    cy.get(mapSelector).trigger('mousemove', 190, 340, { which: 1 });
+
+    cy.window().then(({ map }) => {
+      expect(map.pm.getGeomanDrawLayers().length).to.eq(1);
+      done();
+    });
+  });
 });

--- a/cypress/e2e/marker.cy.js
+++ b/cypress/e2e/marker.cy.js
@@ -317,7 +317,7 @@ describe('Draw Marker', () => {
     });
   });
 
-  it('does not create additional marker while dragging in draw mode ', () => {
+  it('does not create additional marker while dragging in draw mode', () => {
     cy.toolbarButton('marker').click();
 
     cy.get(mapSelector).click(150, 250);

--- a/src/js/Draw/L.PM.Draw.Marker.js
+++ b/src/js/Draw/L.PM.Draw.Marker.js
@@ -6,6 +6,8 @@ Draw.Marker = Draw.extend({
     this._map = map;
     this._shape = 'Marker';
     this.toolbarButtonName = 'drawMarker';
+    // with _layerIsDragging we check if a marker is currently dragged and disable marker creation
+    this._layerIsDragging = false;
   },
   enable(options) {
     // TODO: Think about if these options could be passed globally for all
@@ -137,7 +139,7 @@ Draw.Marker = Draw.extend({
     this._fireChange(this._hintMarker.getLatLng(), 'Draw');
   },
   _createMarker(e) {
-    if (!e.latlng) {
+    if (!e.latlng || this._layerIsDragging) {
       return;
     }
 

--- a/src/js/Edit/L.PM.Edit.Marker.js
+++ b/src/js/Edit/L.PM.Edit.Marker.js
@@ -32,6 +32,9 @@ Edit.Marker = Edit.extend({
 
     this._enabled = true;
 
+    this._layer.on('pm:dragstart', this._onDragStart, this);
+    this._layer.on('pm:dragend', this._onMarkerDragEnd, this);
+
     this._fireEnable();
   },
   disable() {
@@ -88,6 +91,12 @@ Edit.Marker = Edit.extend({
     // TODO: find out why this is fired manually, shouldn't it be catched by L.PM.Map 'layerremove'?
     this._fireRemove(marker);
     this._fireRemove(this._map, marker);
+  },
+  _onDragStart() {
+    this._map.pm.Draw.Marker._layerIsDragging = true;
+  },
+  _onMarkerDragEnd() {
+    this._map.pm.Draw.Marker._layerIsDragging = false;
   },
   _onDragEnd() {
     this._fireEdit();


### PR DESCRIPTION
Prevent the creation of an additional Marker when dragging a Marker in "Create Marker" mode. Fixes: #1568 

  - Replicate CircleMarker _layerIsDragging functionality in Marker