### PR TITLE
unmounting custom controls

### DIFF
--- a/cypress/e2e/toolbar.cy.js
+++ b/cypress/e2e/toolbar.cy.js
@@ -525,4 +525,46 @@ describe('Testing the Toolbar', () => {
       done();
     });
   });
+
+  it('Deletes custom control and adds a new one with the same name', () => {
+    const clickSpy = cy.spy();
+    const clickSpyNew = cy.spy();
+
+    cy.window().then(({ map }) => {
+      map.pm.Toolbar.createCustomControl({
+        name: 'alertBox',
+        onClick: clickSpy,
+        toggle: false,
+        block: 'custom',
+      });
+
+      cy.toolbarButtonContainer('alertBox', map).then((container) => {
+        container[0].children[0].click(); // button
+      });
+    });
+
+    cy.window().then(({ map }) => {
+      // expect needs to be in the this block, otherwise it will be executed before the click event
+      expect(clickSpy.callCount).to.be.eq(1);
+
+      map.pm.Toolbar.deleteControl('alertBox');
+
+      map.pm.Toolbar.createCustomControl({
+        name: 'alertBox',
+        onClick: clickSpyNew,
+        toggle: false,
+        block: 'custom',
+      });
+
+      cy.toolbarButtonContainer('alertBox', map).then((container) => {
+        container[0].children[0].click(); // button
+      });
+    });
+
+    cy.window().then(() => {
+      // expect needs to be in the this block, otherwise it will be executed before the click event
+      expect(clickSpy.callCount).to.be.eq(1);
+      expect(clickSpyNew.callCount).to.be.eq(1);
+    });
+  });
 });

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1088,7 +1088,7 @@ declare module 'leaflet' {
       /** Disable button by control name */
       setButtonDisabled(name: TOOLBAR_CONTROL_ORDER, state: boolean): void;
 
-      /** Removes a custom Control from the Toolbar */
+      /** Deletes and removes a Control from the Toolbar */
       deleteControl(name: string): void;
     }
 

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1087,6 +1087,9 @@ declare module 'leaflet' {
 
       /** Disable button by control name */
       setButtonDisabled(name: TOOLBAR_CONTROL_ORDER, state: boolean): void;
+
+      /** Removes a custom Control from the Toolbar */
+      deleteControl(name: string): void;
     }
 
     type KEYBOARD_EVENT_TYPE = 'current' | 'keydown' | 'keyup';

--- a/src/js/Toolbar/L.PM.Toolbar.js
+++ b/src/js/Toolbar/L.PM.Toolbar.js
@@ -151,6 +151,13 @@ const Toolbar = L.Class.extend({
 
     this.isVisible = false;
   },
+  deleteControl(name) {
+    const btnName = this._btnNameMapping(name);
+    if (this.buttons[btnName]) {
+      this.buttons[btnName].remove();
+      delete this.buttons[btnName];
+    }
+  },
   toggleControls(options = this.options) {
     if (this.isVisible) {
       this.removeControls();


### PR DESCRIPTION
This PR is addressing #1407 and [this](https://stackoverflow.com/questions/73737137/leaflet-geoman-button-with-this-name-already-exists-error-when-creating-a-new) issue

Creating a custom control inside `useEffect` would throw the error 'Button with this name already exists'. This occurs because there was no option to remove the custom button from the toolbar when a component unmounts.

[codesandbox](https://codesandbox.io/p/devbox/react-leaflet-bug-forked-xcmc8y?file=%2Fsrc%2FApp.js&workspaceId=ws_QDWYkU1Sa8Wp6ooBegsLqN)

This is a crucial feature for the React app as it removes custom components from both the toolbar and the UI. Currently, we only have the `removeControls` function, which removes controls from the UI.

