### PR TITLE
Prevent malformed HTML resulting from SVG file

### DIFF
--- a/src/assets/icons/Text.svg
+++ b/src/assets/icons/Text.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><defs><style>.cls-1{fill:none;stroke:#5b5b5b;stroke-linecap:round;stroke-linejoin:round;stroke-width:2.5px;}</style></defs><title>Text</title><g id="Ebene_2" data-name="Ebene 2"><polyline class="cls-1" points="19.64 7.27 19.64 4 12 4 12 20 15.91 20 8.09 20 12 20 12 4 4.36 4 4.36 7.27"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <title>Text</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <polyline points="19.64 7.27 19.64 4 12 4 12 20 15.91 20 8.09 20 12 20 12 4 4.36 4 4.36 7.27" fill="none" stroke="#5b5b5b" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5px"/>
+  </g>
+</svg>


### PR DESCRIPTION
There is an issue when bundling the `@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css` file with Vite.

What happens is that the `<style>` tag of the `Text.svg` file does not get properly escaped and thus produces malformed HTML.

This PR moves the style rules of this SVG from an inline `<style>` tag to SVG HTML properties.