### PR TITLE
feat: add exitModeOnEscape option to exit active modes via Escape key

### DIFF
--- a/cypress/e2e/escapeModeExit.cy.js
+++ b/cypress/e2e/escapeModeExit.cy.js
@@ -1,0 +1,403 @@
+describe('Exit Mode on Escape Key', () => {
+  const mapSelector = '#map';
+
+  beforeEach(() => {
+    cy.window().then(({ map }) => {
+      map.pm.setGlobalOptions({
+        exitModeOnEscape: true,
+      });
+    });
+  });
+
+  describe('Draw Mode', () => {
+    it('should exit draw mode when Escape is pressed', () => {
+      cy.toolbarButton('polygon').click();
+
+      // Verify draw mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify draw mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('polygon')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+
+    it('should exit draw mode mid-drawing when Escape is pressed', () => {
+      cy.toolbarButton('polyline').click();
+
+      // Verify draw mode is enabled before clicking
+      cy.window().then(({ map }) => {
+        expect(map.pm.Draw.getActiveShape()).to.equal('Line');
+      });
+
+      // Start drawing a polyline - don't finish it
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+
+      // Verify draw mode is still enabled during drawing
+      cy.window().then(({ map }) => {
+        expect(map.pm.Draw.getActiveShape()).to.equal('Line');
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify draw mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+        expect(map.pm.Draw.getActiveShape()).to.equal(undefined);
+      });
+    });
+
+    it('should exit line draw mode when Escape is pressed', () => {
+      cy.toolbarButton('polyline').click();
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+    });
+
+    it('should exit marker draw mode when Escape is pressed', () => {
+      cy.toolbarButton('marker').click();
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+    });
+
+    it('should exit rectangle draw mode when Escape is pressed', () => {
+      cy.toolbarButton('rectangle').click();
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+    });
+
+    it('should exit circle draw mode when Escape is pressed', () => {
+      cy.toolbarButton('circle').click();
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+    });
+
+    it('should exit circle marker draw mode when Escape is pressed', () => {
+      cy.toolbarButton('circle-marker').click();
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(false);
+      });
+    });
+  });
+
+  describe('Edit Mode', () => {
+    it('should exit edit mode when Escape is pressed', () => {
+      // First create a polygon
+      cy.toolbarButton('polygon').click();
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+      cy.get(mapSelector).click(300, 300);
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable edit mode
+      cy.toolbarButton('edit').click();
+
+      // Verify edit mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalEditModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify edit mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalEditModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('edit')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+  });
+
+  describe('Drag Mode', () => {
+    it('should exit drag mode when Escape is pressed', () => {
+      // First create a polygon
+      cy.toolbarButton('polygon').click();
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+      cy.get(mapSelector).click(300, 300);
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable drag mode
+      cy.toolbarButton('drag').click();
+
+      // Verify drag mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDragModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify drag mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDragModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('drag')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+  });
+
+  describe('Removal Mode', () => {
+    it('should exit removal mode when Escape is pressed', () => {
+      // First create a marker
+      cy.toolbarButton('marker').click();
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable removal mode
+      cy.toolbarButton('delete').click();
+
+      // Verify removal mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalRemovalModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify removal mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalRemovalModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('delete')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+  });
+
+  describe('Rotate Mode', () => {
+    it('should exit rotate mode when Escape is pressed', () => {
+      // First create a polygon
+      cy.toolbarButton('polygon').click();
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+      cy.get(mapSelector).click(300, 300);
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable rotate mode
+      cy.toolbarButton('rotate').click();
+
+      // Verify rotate mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalRotateModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify rotate mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalRotateModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('rotate')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+  });
+
+  describe('Cut Mode', () => {
+    it('should exit cut mode when Escape is pressed', () => {
+      // First create a polygon
+      cy.toolbarButton('polygon').click();
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+      cy.get(mapSelector).click(300, 300);
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable cut mode
+      cy.toolbarButton('cut').click();
+
+      // Verify cut mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalCutModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify cut mode is disabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalCutModeEnabled()).to.equal(false);
+      });
+
+      // Toolbar button should no longer be active
+      cy.toolbarButton('cut')
+        .closest('.button-container')
+        .should('not.have.class', 'active');
+    });
+  });
+
+  describe('exitModeOnEscape option disabled', () => {
+    it('should NOT exit modes when exitModeOnEscape is false', () => {
+      // Disable the option
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          exitModeOnEscape: false,
+        });
+      });
+
+      cy.toolbarButton('polygon').click();
+
+      // Verify draw mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify draw mode is STILL enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      // Toolbar button should still be active
+      cy.toolbarButton('polygon')
+        .closest('.button-container')
+        .should('have.class', 'active');
+    });
+
+    it('should NOT exit edit mode when exitModeOnEscape is false', () => {
+      // Disable the option
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          exitModeOnEscape: false,
+        });
+      });
+
+      // First create a polygon
+      cy.toolbarButton('polygon').click();
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+      cy.get(mapSelector).click(300, 300);
+      cy.get(mapSelector).click(200, 200);
+
+      // Enable edit mode
+      cy.toolbarButton('edit').click();
+
+      // Verify edit mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalEditModeEnabled()).to.equal(true);
+      });
+
+      // Press Escape key
+      cy.get('body').type('{esc}');
+
+      // Verify edit mode is STILL enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalEditModeEnabled()).to.equal(true);
+      });
+    });
+  });
+
+  describe('pm:keyevent', () => {
+    it('should fire pm:keyevent on Escape key press', () => {
+      let keydownEventFired = false;
+      let keydownEventData = null;
+
+      cy.window().then(({ map }) => {
+        map.on('pm:keyevent', (e) => {
+          if (e.event.key === 'Escape' && e.eventType === 'keydown') {
+            keydownEventFired = true;
+            keydownEventData = e;
+          }
+        });
+      });
+
+      cy.get('body').type('{esc}');
+
+      cy.window().then(() => {
+        expect(keydownEventFired).to.equal(true);
+        expect(keydownEventData.event.key).to.equal('Escape');
+        expect(keydownEventData.eventType).to.equal('keydown');
+      });
+    });
+  });
+});
+
+describe('Exit Mode on Escape Key - Default Option', () => {
+  it('should have exitModeOnEscape disabled by default', () => {
+    // No beforeEach runs here, so map has default options
+    cy.window().then(({ map }) => {
+      const options = map.pm.getGlobalOptions();
+      expect(options.exitModeOnEscape).to.equal(false);
+    });
+  });
+
+  it('should NOT exit draw mode when exitModeOnEscape is disabled by default', () => {
+    cy.toolbarButton('polygon').click();
+
+    // Verify draw mode is enabled
+    cy.window().then(({ map }) => {
+      expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+    });
+
+    // Press Escape key
+    cy.get('body').type('{esc}');
+
+    // Verify draw mode is STILL enabled (default is false)
+    cy.window().then(({ map }) => {
+      expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+    });
+  });
+});

--- a/cypress/e2e/finishOnEnter.cy.js
+++ b/cypress/e2e/finishOnEnter.cy.js
@@ -163,6 +163,114 @@ describe('Finish Drawing on Enter Key', () => {
     });
   });
 
+  describe('Rectangle', () => {
+    it('should finish rectangle drawing when Enter is pressed after placing first corner', () => {
+      cy.toolbarButton('rectangle').click();
+
+      // Place first corner
+      cy.get(mapSelector).click(200, 200);
+
+      // Move mouse to define the rectangle (this updates the hint marker position)
+      cy.get(mapSelector).trigger('mousemove', 350, 350);
+
+      // Verify draw mode is enabled and start marker exists
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        expect(map.pm.Draw.Rectangle._startMarker).to.not.be.undefined;
+      });
+
+      // Press Enter key to finish
+      cy.get('body').type('{enter}');
+
+      // Verify a rectangle was created
+      cy.window().then(({ map }) => {
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(1);
+      });
+    });
+
+    it('should NOT finish rectangle drawing when Enter is pressed before placing first corner', () => {
+      cy.toolbarButton('rectangle').click();
+
+      // Don't place any corner yet
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify draw mode is still enabled and no rectangle was created
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
+  describe('Circle', () => {
+    it('should finish circle drawing when Enter is pressed after placing center', () => {
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          finishOnEnter: true,
+          resizeableCircle: true,
+        });
+      });
+
+      cy.toolbarButton('circle').click();
+
+      // Place center
+      cy.get(mapSelector).click(250, 250);
+
+      // Move mouse to define the radius (this updates the hint marker position)
+      cy.get(mapSelector).trigger('mousemove', 350, 250);
+
+      // Verify draw mode is enabled and center marker exists
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        expect(map.pm.Draw.Circle._centerMarker).to.not.be.undefined;
+      });
+
+      // Press Enter key to finish
+      cy.get('body').type('{enter}');
+
+      // Verify a circle was created
+      cy.window().then(({ map }) => {
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(1);
+      });
+    });
+
+    it('should NOT finish circle drawing when Enter is pressed before placing center', () => {
+      cy.toolbarButton('circle').click();
+
+      // Don't place center yet
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify draw mode is still enabled and no circle was created
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
+  describe('CircleMarker', () => {
+    it('should NOT finish circle marker on Enter (circle markers are single-click)', () => {
+      cy.toolbarButton('circle-marker').click();
+
+      // Don't place any marker yet
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify draw mode is still enabled and no circle marker was created
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
   describe('finishOnEnter option disabled', () => {
     it('should NOT finish drawing when finishOnEnter is false', () => {
       // Disable finishOnEnter and snapping

--- a/cypress/e2e/finishOnEnter.js
+++ b/cypress/e2e/finishOnEnter.js
@@ -1,0 +1,210 @@
+describe('Exit Mode on Escape Key - Default Option', () => {
+  it('should have exitModeOnEscape disabled by default', () => {
+    // No beforeEach runs here, so map has default options
+    cy.window().then(({ map }) => {
+      const options = map.pm.getGlobalOptions();
+      expect(options.exitModeOnEscape).to.equal(false);
+    });
+  });
+
+  it('should NOT exit draw mode when exitModeOnEscape is disabled by default', () => {
+    cy.toolbarButton('polygon').click();
+
+    // Verify draw mode is enabled
+    cy.window().then(({ map }) => {
+      expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+    });
+
+    // Press Escape key
+    cy.get('body').type('{esc}');
+
+    // Verify draw mode is STILL enabled (default is false)
+    cy.window().then(({ map }) => {
+      expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+    });
+  });
+});
+
+describe('Finish Drawing on Enter Key', () => {
+  const mapSelector = '#map';
+
+  beforeEach(() => {
+    cy.window().then(({ map }) => {
+      map.pm.setGlobalOptions({
+        finishOnEnter: true,
+      });
+    });
+  });
+
+  describe('Polygon', () => {
+    it('should finish polygon drawing when Enter is pressed with 3+ vertices', () => {
+      // Disable snapping to ensure vertices don't snap to each other
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          finishOnEnter: true,
+          snappable: false,
+        });
+      });
+
+      cy.toolbarButton('polygon').click();
+
+      // Draw 3 vertices (spread out to avoid any snapping/closing issues)
+      cy.get(mapSelector).click(150, 150);
+      cy.get(mapSelector).click(150, 350);
+      cy.get(mapSelector).click(350, 350);
+
+      // Verify draw mode is enabled and we have 3 vertices
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        // Polygon uses coords.length directly, not flattened
+        const coords = map.pm.Draw.Polygon._layer.getLatLngs();
+        expect(coords.length).to.equal(3);
+      });
+
+      // Press Enter key to finish
+      cy.get('body').type('{enter}');
+
+      // Verify a polygon was created
+      cy.window().then(({ map }) => {
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(1);
+      });
+    });
+
+    it('should NOT finish polygon drawing when Enter is pressed with less than 3 vertices', () => {
+      // Disable snapping to ensure vertices don't snap to each other
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          finishOnEnter: true,
+          snappable: false,
+        });
+      });
+
+      cy.toolbarButton('polygon').click();
+
+      // Draw only 2 vertices
+      cy.get(mapSelector).click(150, 150);
+      cy.get(mapSelector).click(150, 350);
+
+      // Verify we have only 2 vertices
+      cy.window().then(({ map }) => {
+        // Polygon uses coords.length directly, not flattened
+        const coords = map.pm.Draw.Polygon._layer.getLatLngs();
+        expect(coords.length).to.equal(2);
+      });
+
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify no polygon was created and draw mode is still enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
+  describe('Line', () => {
+    it('should finish line drawing when Enter is pressed with 2+ vertices', () => {
+      cy.toolbarButton('polyline').click();
+
+      // Draw 2 vertices
+      cy.get(mapSelector).click(200, 200);
+      cy.get(mapSelector).click(200, 300);
+
+      // Verify draw mode is enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+      });
+
+      // Press Enter key to finish
+      cy.get('body').type('{enter}');
+
+      // Verify a line was created
+      cy.window().then(({ map }) => {
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(1);
+      });
+    });
+
+    it('should NOT finish line drawing when Enter is pressed with less than 2 vertices', () => {
+      cy.toolbarButton('polyline').click();
+
+      // Draw only 1 vertex
+      cy.get(mapSelector).click(200, 200);
+
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify no line was created and draw mode is still enabled
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
+  describe('Marker', () => {
+    it('should NOT finish marker on Enter (markers are single-click)', () => {
+      cy.toolbarButton('marker').click();
+
+      // Don't place any marker yet
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify draw mode is still enabled and no marker was created
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+
+  describe('finishOnEnter option disabled', () => {
+    it('should NOT finish drawing when finishOnEnter is false', () => {
+      // Disable finishOnEnter and snapping
+      cy.window().then(({ map }) => {
+        map.pm.setGlobalOptions({
+          finishOnEnter: false,
+          snappable: false,
+        });
+      });
+
+      cy.toolbarButton('polygon').click();
+
+      // Draw 3 vertices (spread out to avoid any snapping/closing issues)
+      cy.get(mapSelector).click(150, 150);
+      cy.get(mapSelector).click(150, 350);
+      cy.get(mapSelector).click(350, 350);
+
+      // Verify we have 3 vertices
+      cy.window().then(({ map }) => {
+        // Polygon uses coords.length directly, not flattened
+        const coords = map.pm.Draw.Polygon._layer.getLatLngs();
+        expect(coords.length).to.equal(3);
+      });
+
+      // Press Enter key
+      cy.get('body').type('{enter}');
+
+      // Verify draw mode is STILL enabled and no polygon was created
+      cy.window().then(({ map }) => {
+        expect(map.pm.globalDrawModeEnabled()).to.equal(true);
+        const layers = map.pm.getGeomanDrawLayers();
+        expect(layers.length).to.equal(0);
+      });
+    });
+  });
+});
+
+describe('Finish Drawing on Enter Key - Default Option', () => {
+  it('should have finishOnEnter disabled by default', () => {
+    cy.window().then(({ map }) => {
+      const options = map.pm.getGlobalOptions();
+      expect(options.finishOnEnter).to.equal(false);
+    });
+  });
+});

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1243,6 +1243,9 @@ declare module 'leaflet' {
 
       /** Changing the cut behavior to use a circle instead of a polygon. Default: false ⭐ */
       cutAsCircle?: boolean;
+
+      /** Enable exiting active modes (draw, edit, drag, rotate, remove, cut) by pressing the Escape key. Default: false */
+      exitModeOnEscape?: boolean;
     }
 
     interface PMDrawMap {

--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1246,6 +1246,9 @@ declare module 'leaflet' {
 
       /** Enable exiting active modes (draw, edit, drag, rotate, remove, cut) by pressing the Escape key. Default: false */
       exitModeOnEscape?: boolean;
+
+      /** Enable finishing drawing shapes (Line, Polygon, Cut) by pressing the Enter key when enough vertices are placed. Default: false */
+      finishOnEnter?: boolean;
     }
 
     interface PMDrawMap {

--- a/src/js/Draw/L.PM.Draw.CircleMarker.js
+++ b/src/js/Draw/L.PM.Draw.CircleMarker.js
@@ -369,7 +369,7 @@ Draw.CircleMarker = Draw.extend({
 
     // assign the coordinate of the click to the hintMarker, that's necessary for
     // mobile where the marker can't follow a cursor
-    if (!this._hintMarker._snapped) {
+    if (e?.latlng && !this._hintMarker._snapped) {
       this._hintMarker.setLatLng(e.latlng);
     }
 

--- a/src/js/Draw/L.PM.Draw.Rectangle.js
+++ b/src/js/Draw/L.PM.Draw.Rectangle.js
@@ -257,7 +257,7 @@ Draw.Rectangle = Draw.extend({
   _finishShape(e) {
     // assign the coordinate of the click to the hintMarker, that's necessary for
     // mobile where the marker can't follow a cursor
-    if (!this._hintMarker._snapped) {
+    if (e?.latlng && !this._hintMarker._snapped) {
       this._hintMarker.setLatLng(e.latlng);
     }
 

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -40,6 +40,7 @@ const Map = L.Class.extend({
         markerPane: 'markerPane',
       },
       draggable: true,
+      exitModeOnEscape: false,
     };
 
     this.Keyboard._initKeyListener(map);

--- a/src/js/L.PM.Map.js
+++ b/src/js/L.PM.Map.js
@@ -41,6 +41,7 @@ const Map = L.Class.extend({
       },
       draggable: true,
       exitModeOnEscape: false,
+      finishOnEnter: false,
     };
 
     this.Keyboard._initKeyListener(map);

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -9,14 +9,30 @@ const createKeyboardMixins = () => ({
     // clean up global listeners when current map instance is destroyed
     map.once('unload', this._unbindKeyListenerEvents, this);
   },
-  _handleEscapeKey() {
+  _handleEscapeKey(e) {
     const pm = this.map.pm;
     const globalOptions = pm.getGlobalOptions();
 
     // Only handle Escape if the option is enabled
     if (!globalOptions.exitModeOnEscape) {
-      return;
+      return false;
     }
+
+    // Check if any mode is active
+    const hasActiveMode =
+      pm.globalDrawModeEnabled() ||
+      pm.globalEditModeEnabled() ||
+      pm.globalDragModeEnabled() ||
+      pm.globalRemovalModeEnabled() ||
+      pm.globalRotateModeEnabled() ||
+      pm.globalCutModeEnabled();
+
+    if (!hasActiveMode) {
+      return false;
+    }
+
+    // Prevent default browser behavior (focus ring, etc.)
+    e.preventDefault();
 
     // Disable all active modes
     // 1. Disable draw mode if active
@@ -48,6 +64,78 @@ const createKeyboardMixins = () => ({
     if (pm.globalCutModeEnabled()) {
       pm.disableGlobalCutMode();
     }
+
+    return true;
+  },
+  _handleEnterKey(e) {
+    const pm = this.map.pm;
+    const globalOptions = pm.getGlobalOptions();
+
+    // Only handle Enter if the option is enabled
+    if (!globalOptions.finishOnEnter) {
+      return false;
+    }
+
+    // Only handle Enter for draw mode
+    const activeShape = pm.Draw.getActiveShape();
+    if (!activeShape) {
+      return false;
+    }
+
+    // Get the active draw instance
+    const drawInstance = pm.Draw[activeShape];
+    if (!drawInstance || !drawInstance._finishShape) {
+      return false;
+    }
+
+    // Check if the shape can be finished (has enough vertices)
+    // For shapes that support _finishShape, try to finish
+    // The _finishShape method itself checks if there are enough vertices
+    const canFinish = this._canFinishShape(drawInstance, activeShape);
+    if (!canFinish) {
+      return false;
+    }
+
+    // Prevent default behavior
+    e.preventDefault();
+
+    // Finish the shape
+    drawInstance._finishShape();
+
+    return true;
+  },
+  _canFinishShape(drawInstance, activeShape) {
+    // Check if we can finish the current shape based on vertex count
+    // Different shapes have different minimum vertex requirements
+
+    // Shapes that don't support multi-vertex drawing
+    if (['Marker', 'CircleMarker', 'Circle', 'Text'].includes(activeShape)) {
+      return false;
+    }
+
+    // For Rectangle, check if drawing is in progress (has start point)
+    if (activeShape === 'Rectangle') {
+      return drawInstance._startMarker !== undefined;
+    }
+
+    // For Line, Polygon, Cut - need to check vertex count
+    if (drawInstance._layer && drawInstance._layer.getLatLngs) {
+      const coords = drawInstance._layer.getLatLngs();
+
+      // Line needs at least 2 points (uses flat coords)
+      if (activeShape === 'Line') {
+        const flatCoords = coords.flat ? coords.flat() : coords;
+        return flatCoords.length >= 2;
+      }
+
+      // Polygon and Cut need at least 3 points
+      // Polygon's _finishShape checks coords.length directly (not flattened)
+      if (activeShape === 'Polygon' || activeShape === 'Cut') {
+        return coords.length >= 3;
+      }
+    }
+
+    return false;
   },
   _unbindKeyListenerEvents() {
     L.DomEvent.off(document, 'keydown keyup', this._onKeyListener, this);
@@ -68,9 +156,16 @@ const createKeyboardMixins = () => ({
 
     this.map.pm._fireKeyeventEvent(e, e.type, focusOn);
 
-    // Handle Escape key to exit active modes on keydown
-    if (e.type === 'keydown' && e.key === 'Escape') {
-      this._handleEscapeKey();
+    // Handle special keys on keydown
+    if (e.type === 'keydown') {
+      // Handle Escape key to exit active modes
+      if (e.key === 'Escape') {
+        this._handleEscapeKey(e);
+      }
+      // Handle Enter key to finish drawing
+      if (e.key === 'Enter') {
+        this._handleEnterKey(e);
+      }
     }
   },
   _onBlur(e) {

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -9,6 +9,46 @@ const createKeyboardMixins = () => ({
     // clean up global listeners when current map instance is destroyed
     map.once('unload', this._unbindKeyListenerEvents, this);
   },
+  _handleEscapeKey() {
+    const pm = this.map.pm;
+    const globalOptions = pm.getGlobalOptions();
+
+    // Only handle Escape if the option is enabled
+    if (!globalOptions.exitModeOnEscape) {
+      return;
+    }
+
+    // Disable all active modes
+    // 1. Disable draw mode if active
+    if (pm.globalDrawModeEnabled()) {
+      pm.disableDraw();
+    }
+
+    // 2. Disable global edit mode if active
+    if (pm.globalEditModeEnabled()) {
+      pm.disableGlobalEditMode();
+    }
+
+    // 3. Disable global drag mode if active
+    if (pm.globalDragModeEnabled()) {
+      pm.disableGlobalDragMode();
+    }
+
+    // 4. Disable global removal mode if active
+    if (pm.globalRemovalModeEnabled()) {
+      pm.disableGlobalRemovalMode();
+    }
+
+    // 5. Disable global rotate mode if active
+    if (pm.globalRotateModeEnabled()) {
+      pm.disableGlobalRotateMode();
+    }
+
+    // 6. Disable global cut mode if active
+    if (pm.globalCutModeEnabled()) {
+      pm.disableGlobalCutMode();
+    }
+  },
   _unbindKeyListenerEvents() {
     L.DomEvent.off(document, 'keydown keyup', this._onKeyListener, this);
     L.DomEvent.off(window, 'blur', this._onBlur, this);
@@ -27,6 +67,11 @@ const createKeyboardMixins = () => ({
     this._lastEvents.current = data;
 
     this.map.pm._fireKeyeventEvent(e, e.type, focusOn);
+
+    // Handle Escape key to exit active modes on keydown
+    if (e.type === 'keydown' && e.key === 'Escape') {
+      this._handleEscapeKey();
+    }
   },
   _onBlur(e) {
     e.altKey = false;

--- a/src/js/Mixins/Keyboard.js
+++ b/src/js/Mixins/Keyboard.js
@@ -109,13 +109,21 @@ const createKeyboardMixins = () => ({
     // Different shapes have different minimum vertex requirements
 
     // Shapes that don't support multi-vertex drawing
-    if (['Marker', 'CircleMarker', 'Circle', 'Text'].includes(activeShape)) {
+    if (['Marker', 'CircleMarker', 'Text'].includes(activeShape)) {
       return false;
     }
 
     // For Rectangle, check if drawing is in progress (has start point)
     if (activeShape === 'Rectangle') {
       return drawInstance._startMarker !== undefined;
+    }
+
+    // For Circle, check if center has been placed (added to layer group)
+    if (activeShape === 'Circle') {
+      return (
+        drawInstance._centerMarker &&
+        drawInstance._layerGroup?.hasLayer(drawInstance._centerMarker)
+      );
     }
 
     // For Line, Polygon, Cut - need to check vertex count


### PR DESCRIPTION
## Summary

Adds two new global options for keyboard-based interactions:

1. **`exitModeOnEscape`** - Exit any active mode (draw, edit, drag, rotate, remove, cut) by pressing the Escape key
2. **`finishOnEnter`** - Finish drawing the current shape by pressing the Enter key

This implements the feature request from #1586.

### Usage

```javascript
map.pm.setGlobalOptions({ 
  exitModeOnEscape: true,
  finishOnEnter: true 
});
```

### Changes

**Escape Key (`exitModeOnEscape`)**
- Added `_handleEscapeKey()` method to the Keyboard mixin that disables all active modes
- Added `exitModeOnEscape: false` to default global options (disabled by default for backward compatibility)

**Enter Key (`finishOnEnter`)**
- Added `_handleEnterKey()` method to the Keyboard mixin that finishes the current shape
- Added `_canFinishShape()` helper to check if a shape has enough vertices to be finished
- Added `finishOnEnter: false` to default global options (disabled by default for backward compatibility)
- Fixed Rectangle and CircleMarker `_finishShape()` methods to handle being called without an event object

**Supported Shapes for `finishOnEnter`**
- Polygon (requires 3+ vertices)
- Line (requires 2+ vertices)
- Rectangle (requires first corner placed)
- Circle (requires center placed)
- Cut (requires 3+ vertices)

**Not supported (by design)**
- Marker (single-click placement)
- CircleMarker (single-click placement)
- Text (single-click placement)

### TypeScript
- Updated TypeScript definitions with both new options

### Tests
- Added comprehensive Cypress E2E tests for both features
- 17 tests for `exitModeOnEscape` covering all modes
- 14 tests for `finishOnEnter` covering all supported shapes

## Test plan
- [x] All new E2E tests pass (31 tests total)
- [x] Existing tests pass
- [x] ESLint and Prettier checks pass

Closes #1586