### PR TITLE
Update TypeScript definitions to match implementation

### DIFF
--- a/leaflet-geoman.d.ts
+++ b/leaflet-geoman.d.ts
@@ -1084,9 +1084,9 @@ declare module 'leaflet' {
       /** Creates a copy of a draw Control. Returns the drawInstance and the control. */
       copyDrawControl(
         copyInstance: string,
-        options: CustomControlOptions
+        options: CustomControlOptions | string
       ): {
-        drawInstance: Draw;
+        drawInstance: DrawShape;
         control: L.Control;
       };
 
@@ -1632,6 +1632,10 @@ declare module 'leaflet' {
       /** Returns the active shape. */
       getActiveShape(): SUPPORTED_SHAPES;
 
+      /** Creates a new draw instance for custom controls. */
+      createNewDrawInstance(name: string, jsClass: string): DrawShape;
+
+      /** Access shape-specific draw instances (e.g., Draw.Line, Draw.Marker) */
       [key: string]: DrawShape | ((...args: any[]) => any);
     }
 
@@ -1647,6 +1651,15 @@ declare module 'leaflet' {
 
       /** Get options */
       getOptions(): DrawModeOptions;
+
+      /** The current options for this draw shape */
+      options?: DrawModeOptions;
+
+      /** The toolbar button name associated with this draw instance */
+      toolbarButtonName?: string;
+
+      /** The shape identifier */
+      _shape?: string;
     }
 
     interface LassoDraw {
@@ -1853,6 +1866,9 @@ declare module 'leaflet' {
     interface DrawModeOptions extends SnappingOptions {
       /** Require the last point of a shape to be snapped. (default: false). */
       requireSnapToFinish?: boolean;
+
+      /** Enable finishing drawing shapes (Line, Polygon, Cut) by pressing the Enter key when enough vertices are placed. (default: false) */
+      finishOnEnter?: boolean;
 
       /** Show helpful tooltips for your user (default:true). */
       tooltips?: boolean;


### PR DESCRIPTION
## Description

This PR updates the TypeScript type definitions to accurately reflect the actual JavaScript implementation. Several method signatures and type annotations were missing or incorrect.

## Related Issue

Fixes #1617

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)

## Changes

- `copyDrawControl` now correctly accepts `CustomControlOptions | string` for the options parameter
- Return type of `copyDrawControl` changed from `Draw` to `DrawShape`
- Added missing `createNewDrawInstance` method to the Draw interface
- Added missing optional properties to DrawShape: `options`, `toolbarButtonName`, `_shape`
- Added missing `finishOnEnter` option to DrawModeOptions

## Checklist

- [x] Changes match the actual implementation
- [x] TypeScript definitions compile without errors