### PR TITLE
test: add E2E coverage for touch hint feature

### DIFF
--- a/cypress/e2e/tooltips.cy.js
+++ b/cypress/e2e/tooltips.cy.js
@@ -52,6 +52,34 @@ describe('Shows Tooltips', () => {
     cy.get('.leaflet-tooltip-bottom').should('not.exist');
   });
 
+  // Test adapted from PR #1597 (JoonasAapro) for touch hint feature
+  it('Shows touch hint on devices without fine pointer', () => {
+    // Mock matchMedia to simulate coarse pointer (touch device)
+    cy.window().then((win) => {
+      cy.stub(win, 'matchMedia').callsFake((query) => ({
+        matches: query === '(pointer: coarse)',
+      }));
+    });
+
+    cy.get('.leaflet-pm-touch-hint').should('not.exist');
+
+    cy.toolbarButton('marker').click();
+    cy.get('.leaflet-pm-touch-hint').should('exist');
+
+    cy.get('.leaflet-pm-touch-hint').then((el) => {
+      expect(el).to.have.text('Tap the map to place a marker');
+    });
+
+    cy.get(mapSelector).click(290, 250);
+
+    // Hint should persist after placing marker (continueDrawing default)
+    cy.get('.leaflet-pm-touch-hint').should('exist');
+
+    cy.toolbarButton('marker').click();
+
+    cy.get('.leaflet-pm-touch-hint').should('not.exist');
+  });
+
   it('Has Rectangle Tooltips', () => {
     cy.get('.leaflet-tooltip-bottom').should('not.exist');
     cy.toolbarButton('rectangle').click();


### PR DESCRIPTION
## Description

Adds Cypress E2E test for the touch hint feature introduced in PR #1627. The test verifies that touch devices (detected via coarse pointer) show a persistent hint banner instead of a cursor-following marker. Test approach adapted from PR #1597 (credit: JoonasAapro).

## Related Issue

Covers test gap from PR #1627 and validates approach from PR #1597.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project (run `npm run lint`)
- [x] I have tested my changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes (`npm run test:all`)