### PR TITLE
docs: document TypeScript casting of event payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,40 @@
 
 Visit [geoman.io/docs](https://www.geoman.io/docs) to get started.
 
+### TypeScript
+
+The `layer` property on Geoman event payloads is typed as the base `L.Layer` because events like `pm:edit` fire for every shape type. To access shape-specific APIs such as `Polygon.getLatLngs()`, narrow the type using one of the two patterns below.
+
+#### `instanceof` narrowing (recommended)
+
+TypeScript narrows the type automatically inside the `if` block — no cast needed.
+
+```ts
+import { Map, Polygon } from 'leaflet';
+
+map.on('pm:edit', (e) => {
+  if (e.layer instanceof Polygon) {
+    e.layer.getLatLngs();
+  }
+});
+```
+
+#### `as` cast branched on `e.shape`
+
+When you already know the shape from `e.shape` (a `PM.SUPPORTED_SHAPES` value), you can cast directly:
+
+```ts
+import { Polygon } from 'leaflet';
+
+map.on('pm:edit', (e) => {
+  if (e.shape === 'Polygon') {
+    (e.layer as Polygon).getLatLngs();
+  }
+});
+```
+
+The event payload type is `PM.EditEventHandler` (see `leaflet-geoman.d.ts`), which exposes `shape: PM.SUPPORTED_SHAPES` and `layer: L.Layer`.
+
 ## Demo
 
 Check out the full power of Leaflet-Geoman Pro on [geoman.io/demo](https://www.geoman.io/demo)


### PR DESCRIPTION
## Description

Adds a short `### TypeScript` subsection to `README.md` (directly under `## Documentation`) showing how to narrow the `layer` property on Geoman event payloads from `L.Layer` to a shape-specific type. Two patterns are documented:

1. `instanceof` narrowing (recommended) — TypeScript narrows automatically inside the `if` block, no cast needed.
2. `as` cast branched on `e.shape` — for users who already know the shape via the `PM.SUPPORTED_SHAPES` enum.

The second snippet is the exact pattern requested in #1014. The event payload type is `PM.EditEventHandler` (defined in `leaflet-geoman.d.ts`), referenced in the docs so users can find the source of truth.

## Related Issue

Fixes #1014

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project (docs-only change; `npm run lint` unaffected)
- [x] I have tested my changes locally (rendered README preview; markdown renders cleanly)
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — docs only)
- [x] New and existing tests pass locally with my changes (docs-only; no code paths touched)

## Screenshots (if applicable)

N/A — markdown-only change.

## Additional Notes

The issue was open for ~4.5 years (filed 2021-10-19) and references Stack Overflow question 69621270 as additional context for users hitting this. The example from the issue body is preserved verbatim in the second code block.

Fixes #1014

This contribution was developed with AI assistance (Codex).
