### PR TITLE
docs(readme): document TypeScript casting of Geoman event payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@
 
 Visit [geoman.io/docs](https://www.geoman.io/docs) to get started.
 
+### TypeScript: casting the event payload
+
+The `layer` field on Geoman event payloads is typed as `L.Layer`, so reach for the concrete subtype before calling layer-specific methods. Branch on `e.shape` and cast, or narrow with `instanceof` first:
+
+```typescript
+import { Polygon } from 'leaflet';
+
+map.on('pm:edit', (e) => {
+  if (e.shape === 'Polygon') {
+    (e.layer as Polygon).getLatLngs();
+  }
+});
+
+// or, equivalently
+map.on('pm:edit', (e) => {
+  if (e.layer instanceof Polygon) {
+    e.layer.getLatLngs();
+  }
+});
+```
+
+See [#1014](https://github.com/geoman-io/leaflet-geoman/issues/1014) for the original discussion.
+
 ## Demo
 
 Check out the full power of Leaflet-Geoman Pro on [geoman.io/demo](https://www.geoman.io/demo)


### PR DESCRIPTION
Closes #1014.

Geoman event payloads type `layer` as `L.Layer`, so reaching for layer-specific methods (e.g. `getLatLngs()` on a `Polygon`) requires casting or narrowing first. The README didn't show that pattern, so users hit the same TypeScript error the issue reporter ran into (also surfaced on [stackoverflow.com/q/69621270](https://stackoverflow.com/q/69621270)).

Adds a **TypeScript: casting the event payload** subsection under `## Documentation` that:

- Branches on `e.shape` and casts `e.layer` to the concrete subtype - the original snippet from the issue.
- Shows the equivalent `instanceof` narrowing form (which the issue reporter floated as untested but cleaner; it does work and reads better in modern TS).
- Links back to #1014 for the original discussion so future readers can find the rationale.

External `geoman.io/docs` is the deeper reference, but the README is what most TypeScript users hit first when they wire up `pm:edit` and the casting pattern is short enough to live there.