### PR TITLE
chore(ci): bump action-gh-release to v3; verify deps current within cooldown

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           echo "file=$PACKAGE_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ steps.version.outputs.version }}
           tag_name: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Description

Audit of CI action versions and dependency freshness on `develop`:

- **softprops/action-gh-release v2 → v3**: the only action not on its latest major. v3 just moves the action runtime to Node 24 (fine on GitHub-hosted runners); no input/behavior changes.
- All other actions verified already latest: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/cache@v5`, `pnpm/action-setup@v6` (bumped in #1665).
- **Dependencies**: `pnpm outdated` is clean and confirmed to respect the 7-day `minimumReleaseAge` cooldown — cypress 15.17.0 (2.9d), esbuild 0.28.1 (0.6d), oxlint 1.69.0 (3.9d), and oxfmt 0.54.0 (3.4d) all exist but are correctly held back until they age past 7 days; the locked versions are the newest eligible ones.

## Type of Change

- [x] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project (run `pnpm run lint`)
- [x] I have tested my changes locally
- [x] New and existing tests pass locally with my changes (`pnpm run test:all`)